### PR TITLE
fix: replace deprecated JSONPropertiesContainer with AbstractPropContainer

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/dataproc.py
@@ -25,7 +25,8 @@ from spark_rapids_pytools.cloud_api.gstorage import GStorageDriver
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, CMDDriverBase, \
     ClusterBase, ClusterNode, SysInfo, GpuHWInfo, SparkNodeType, ClusterState, GpuDevice, \
     NodeHWInfo, ClusterGetAccessor
-from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer, is_valid_gpu_device
+from spark_rapids_tools.utils.propmanager import AbstractPropContainer
+from spark_rapids_pytools.common.prop_manager import is_valid_gpu_device
 from spark_rapids_pytools.common.sys_storage import FSUtil
 from spark_rapids_pytools.common.utilities import Utils
 from spark_rapids_pytools.pricing.dataproc_pricing import DataprocPriceProvider
@@ -114,10 +115,9 @@ class DataprocPlatform(PlatformBase):
                                 source_cost: float = None):
         raw_pricing_config = self.configs.get_value_silent('pricing')
         if raw_pricing_config:
-            pricing_config = JSONPropertiesContainer(prop_arg=raw_pricing_config,
-                                                     file_load=False)
+            pricing_config = AbstractPropContainer(props=raw_pricing_config)
         else:
-            pricing_config: JSONPropertiesContainer = None
+            pricing_config: AbstractPropContainer = None
         pricing_provider = DataprocPriceProvider(region=self.cli.get_region(),
                                                  pricing_configs={'gcloud': pricing_config})
         saving_estimator = DataprocSavingsEstimator(price_provider=pricing_provider,
@@ -319,7 +319,7 @@ class DataprocCMDDriver(CMDDriverBase):  # pylint: disable=abstract-method
             return gpu_name.upper()
 
         processed_instance_descriptions = {}
-        raw_instances_descriptions = JSONPropertiesContainer(prop_arg=instance_descriptions, file_load=False)
+        raw_instances_descriptions = AbstractPropContainer(props=instance_descriptions)
         for instance in raw_instances_descriptions.props:
             instance_content = {}
             instance_content['VCpuCount'] = int(instance.get('guestCpus', -1))
@@ -505,7 +505,7 @@ class DataprocCluster(ClusterBase):
             for worker_node in worker_nodes_from_conf:
                 worker_props = {
                     'name': worker_node,
-                    'props': JSONPropertiesContainer(prop_arg=raw_worker_prop, file_load=False),
+                    'props': AbstractPropContainer(props=raw_worker_prop),
                     # set the node zone based on the wrapper defined zone
                     'zone': self.zone
                 }
@@ -516,7 +516,7 @@ class DataprocCluster(ClusterBase):
         raw_master_props = self.props.get_value('config', 'masterConfig')
         master_props = {
             'name': master_nodes_from_conf[0],
-            'props': JSONPropertiesContainer(prop_arg=raw_master_props, file_load=False),
+            'props': AbstractPropContainer(props=raw_master_props),
             # set the node zone based on the wrapper defined zone
             'zone': self.zone
         }
@@ -527,7 +527,7 @@ class DataprocCluster(ClusterBase):
             SparkNodeType.MASTER: master_node
         }
 
-    def _set_zone_from_props(self, prop_container: JSONPropertiesContainer):
+    def _set_zone_from_props(self, prop_container: AbstractPropContainer):
         """
         Extracts the 'zoneUri' from the properties container and updates the environment variable dictionary.
         """

--- a/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
+++ b/user_tools/src/spark_rapids_pytools/common/cluster_inference.py
@@ -22,7 +22,7 @@ from logging import Logger
 import pandas as pd
 
 from spark_rapids_pytools.cloud_api.sp_types import PlatformBase, ClusterBase
-from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
+from spark_rapids_tools.utils.propmanager import AbstractPropContainer
 from spark_rapids_pytools.common.utilities import ToolLogging
 from spark_rapids_tools import CspEnv
 
@@ -145,7 +145,7 @@ class ClusterInference:
             cluster_conf = self.platform.generate_cluster_configuration(cluster_template_args)
             if cluster_conf is None:
                 return None
-            cluster_props_new = JSONPropertiesContainer(cluster_conf, file_load=False)
+            cluster_props_new = AbstractPropContainer(props=cluster_conf)
             return self.platform.load_cluster_by_prop(cluster_props_new, is_inferred=True)
         except Exception as e:  # pylint: disable=broad-except
             self.logger.error('Error while inferring cluster: %s', str(e))


### PR DESCRIPTION
Replaces deprecated `JSONPropertiesContainer` with `AbstractPropContainer` in two files, per the deprecation warnings on `AbstractPropertiesContainer`, `YAMLPropertiesContainer`, and `JSONPropertiesContainer` in `prop_manager.py`.

## Changes

**`dataproc.py`** (7 call sites):
- Import: `AbstractPropContainer` from `spark_rapids_tools.utils.propmanager`; kept `is_valid_gpu_device` from `prop_manager`
- `JSONPropertiesContainer(prop_arg=X, file_load=False)` → `AbstractPropContainer(props=X)` at 5 locations (pricing config, instance descriptions, worker props, master props)
- Type annotation updates at `pricing_config` parameter and `_set_zone_from_props` signature

**`cluster_inference.py`** (1 call site):
- Import swap to `AbstractPropContainer`
- `JSONPropertiesContainer(cluster_conf, file_load=False)` → `AbstractPropContainer(props=cluster_conf)`

All changes follow the `AbstractPropContainer` API: `props=` for dict wrapping, matching `get_value`/`get_value_silent` method signatures preserved from the parent class.

Closes #1898
