### PR TITLE
fix(user_tools): honor AWS profile S3 endpoints

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/sp_types.py
@@ -28,6 +28,7 @@ from spark_rapids_pytools.common.prop_manager import AbstractPropertiesContainer
 from spark_rapids_pytools.common.sys_storage import StorageDriver, FSUtil
 from spark_rapids_pytools.common.utilities import ToolLogging, SysCmd, Utils, TemplateGenerator
 from spark_rapids_tools import EnumeratedType, CspEnv
+from spark_rapids_tools.storagelib.s3.aws_config import resolve_s3_endpoint_override
 
 
 class DeployMode(EnumeratedType):
@@ -570,8 +571,8 @@ class CMDDriverBase:
             'envArgs': {}
         }
         # Pass custom S3 endpoint to hadoop-aws if set, matching the Python-side
-        # S3Fs handler logic (AWS_ENDPOINT_URL_S3 takes precedence over AWS_ENDPOINT_URL).
-        s3_endpoint = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('AWS_ENDPOINT_URL')
+        # S3Fs handler logic.
+        s3_endpoint = resolve_s3_endpoint_override()
         if s3_endpoint:
             res['jvmArgs']['Drapids.tools.hadoop.fs.s3a.endpoint'] = s3_endpoint
             res['jvmArgs']['Drapids.tools.hadoop.fs.s3a.path.style.access'] = 'true'

--- a/user_tools/src/spark_rapids_tools/storagelib/s3/aws_config.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/s3/aws_config.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AWS S3 endpoint resolution helpers."""
+
+import configparser
+import os
+from pathlib import Path
+from typing import Optional
+
+_AWS_CONFIG_FILE = 'AWS_CONFIG_FILE'
+_AWS_DEFAULT_PROFILE = 'AWS_DEFAULT_PROFILE'
+_AWS_ENDPOINT_URL = 'AWS_ENDPOINT_URL'
+_AWS_ENDPOINT_URL_S3 = 'AWS_ENDPOINT_URL_S3'
+_AWS_PROFILE = 'AWS_PROFILE'
+
+
+def resolve_s3_endpoint_override() -> Optional[str]:
+    """
+    Resolve an S3 endpoint override using explicit environment variables first,
+    then the active AWS profile from the AWS config file.
+    """
+    env_endpoint = os.environ.get(_AWS_ENDPOINT_URL_S3) or os.environ.get(_AWS_ENDPOINT_URL)
+    if env_endpoint:
+        return env_endpoint
+    return _resolve_profile_s3_endpoint()
+
+
+def _resolve_profile_s3_endpoint() -> Optional[str]:
+    config = configparser.ConfigParser()
+    config_path = Path(os.environ.get(_AWS_CONFIG_FILE, Path.home() / '.aws' / 'config')).expanduser()
+    try:
+        if not config_path.exists():
+            return None
+        config.read(config_path)
+    except (configparser.Error, OSError):
+        return None
+
+    for profile_name in _candidate_profile_names():
+        endpoint = _resolve_profile_section_endpoint(config, profile_name)
+        if endpoint:
+            return endpoint
+    return None
+
+
+def _candidate_profile_names() -> list[str]:
+    candidates = [
+        os.environ.get(_AWS_PROFILE),
+        os.environ.get(_AWS_DEFAULT_PROFILE),
+        'default',
+    ]
+    result: list[str] = []
+    for candidate in candidates:
+        if candidate:
+            profile_name = candidate.strip()
+            if profile_name and profile_name not in result:
+                result.append(profile_name)
+    return result
+
+
+def _profile_section(profile_name: str) -> str:
+    return 'default' if profile_name == 'default' else f'profile {profile_name}'
+
+
+def _resolve_profile_section_endpoint(
+        config: configparser.ConfigParser,
+        profile_name: str) -> Optional[str]:
+    section_name = _profile_section(profile_name)
+    if not config.has_section(section_name):
+        return None
+    section = config[section_name]
+
+    services_endpoint = _resolve_services_section_endpoint(config, section.get('services'))
+    if services_endpoint:
+        return services_endpoint
+
+    inline_s3_endpoint = _parse_nested_s3_endpoint(section.get('s3'))
+    if inline_s3_endpoint:
+        return inline_s3_endpoint
+
+    endpoint = section.get('endpoint_url')
+    return endpoint.strip() if endpoint and endpoint.strip() else None
+
+
+def _resolve_services_section_endpoint(
+        config: configparser.ConfigParser,
+        services_name: Optional[str]) -> Optional[str]:
+    if not services_name:
+        return None
+    section_name = f'services {services_name.strip()}'
+    if not config.has_section(section_name):
+        return None
+    return _parse_nested_s3_endpoint(config[section_name].get('s3'))
+
+
+def _parse_nested_s3_endpoint(raw_value: Optional[str]) -> Optional[str]:
+    if not raw_value:
+        return None
+    for line in raw_value.splitlines():
+        key, sep, value = line.strip().partition('=')
+        if sep and key.strip() == 'endpoint_url' and value.strip():
+            return value.strip()
+    return None

--- a/user_tools/src/spark_rapids_tools/storagelib/s3/s3fs.py
+++ b/user_tools/src/spark_rapids_tools/storagelib/s3/s3fs.py
@@ -14,10 +14,10 @@
 
 """Wrapper for the S3 File system"""
 
-import os
 from typing import Any
 
 from spark_rapids_tools.storagelib.cspfs import register_fs_class, CspFs
+from spark_rapids_tools.storagelib.s3.aws_config import resolve_s3_endpoint_override
 
 
 @register_fs_class('s3', 'S3FileSystem')
@@ -45,7 +45,7 @@ class S3Fs(CspFs):
         """
         Create S3FileSystem handler with automatic endpoint detection.
         """
-        endpoint_url = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('AWS_ENDPOINT_URL')
+        endpoint_url = resolve_s3_endpoint_override()
         if endpoint_url and 'endpoint_override' not in kwargs:
             # Only set endpoint_override if it's not already explicitly provided
             kwargs['endpoint_override'] = endpoint_url

--- a/user_tools/tests/spark_rapids_tools_ut/test_csppath.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_csppath.py
@@ -22,6 +22,8 @@ from pydantic_core import PydanticCustomError
 
 from spark_rapids_tools.storagelib import CspFs, CspPath
 from spark_rapids_tools.storagelib.local.localpath import LocalPath
+from spark_rapids_tools.storagelib.s3.aws_config import resolve_s3_endpoint_override
+from spark_rapids_tools.storagelib.s3.s3fs import S3Fs
 from spark_rapids_tools.storagelib.s3.s3path import S3Path
 
 
@@ -102,3 +104,132 @@ class TestCspPathFileInfoCaching:
 
         assert created_path.exists() is True
         assert created_path.is_file() is True
+
+
+class TestS3EndpointResolution:
+    """Verify S3-compatible endpoint override precedence."""
+
+    def test_s3_endpoint_env_takes_precedence_over_profile_config(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text(
+            "[default]\n"
+            "endpoint_url = https://profile.example\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+        monkeypatch.setenv("AWS_ENDPOINT_URL", "https://env.example")
+        monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "https://s3-env.example")
+
+        assert resolve_s3_endpoint_override() == "https://s3-env.example"
+
+    def test_s3_endpoint_resolves_active_profile_endpoint_url(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text(
+            "[default]\n"
+            "endpoint_url = https://default.example\n"
+            "[profile swiftstack]\n"
+            "endpoint_url = https://swiftstack.example\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+        monkeypatch.setenv("AWS_PROFILE", "swiftstack")
+
+        assert resolve_s3_endpoint_override() == "https://swiftstack.example"
+
+    def test_s3_endpoint_resolves_default_profile_endpoint_url(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text(
+            "[default]\n"
+            "endpoint_url = https://default-profile.example\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+        monkeypatch.setenv("AWS_DEFAULT_PROFILE", "default")
+
+        assert resolve_s3_endpoint_override() == "https://default-profile.example"
+
+    def test_s3_endpoint_resolves_profile_services_s3_endpoint(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text(
+            "[profile swiftstack]\n"
+            "services = local-services\n"
+            "[services local-services]\n"
+            "s3 =\n"
+            "  endpoint_url = https://services-s3.example\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+        monkeypatch.setenv("AWS_PROFILE", "swiftstack")
+
+        assert resolve_s3_endpoint_override() == "https://services-s3.example"
+
+    def test_s3_endpoint_resolves_profile_nested_s3_endpoint(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text(
+            "[profile swiftstack]\n"
+            "endpoint_url = https://profile.example\n"
+            "s3 =\n"
+            "  endpoint_url = https://nested-s3.example\n",
+            encoding="utf-8",
+        )
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+        monkeypatch.setenv("AWS_PROFILE", "swiftstack")
+
+        assert resolve_s3_endpoint_override() == "https://nested-s3.example"
+
+    def test_s3_endpoint_ignores_invalid_profile_config(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text("endpoint_url = https://invalid.example\n", encoding="utf-8")
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+
+        assert resolve_s3_endpoint_override() is None
+
+    def test_s3_fs_applies_profile_endpoint_override(self, monkeypatch, tmp_path):
+        config_file = tmp_path / "aws_config"
+        config_file.write_text(
+            "[profile swiftstack]\n"
+            "endpoint_url = https://swiftstack.example\n",
+            encoding="utf-8",
+        )
+        captured_kwargs = {}
+
+        def capture_handler(cls, *args, **kwargs):
+            del cls, args
+            captured_kwargs.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(CspFs, "create_fs_handler", classmethod(capture_handler))
+        monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+        monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+        monkeypatch.setenv("AWS_PROFILE", "swiftstack")
+
+        S3Fs.create_fs_handler()
+
+        assert captured_kwargs["endpoint_override"] == "https://swiftstack.example"
+
+    def test_s3_fs_preserves_explicit_endpoint_override(self, monkeypatch):
+        captured_kwargs = {}
+
+        def capture_handler(cls, *args, **kwargs):
+            del cls, args
+            captured_kwargs.update(kwargs)
+            return object()
+
+        monkeypatch.setattr(CspFs, "create_fs_handler", classmethod(capture_handler))
+        monkeypatch.setenv("AWS_ENDPOINT_URL_S3", "https://env.example")
+
+        S3Fs.create_fs_handler(endpoint_override="https://explicit.example")
+
+        assert captured_kwargs["endpoint_override"] == "https://explicit.example"


### PR DESCRIPTION
## Description

Add a shared S3 endpoint resolver used by both the Python `S3Fs` handler and local Hadoop job argument construction. Existing explicit and environment behavior is preserved, with AWS profile configuration consulted only when no endpoint environment variable is set.

Endpoint precedence is:

1. explicit `endpoint_override` argument for `S3Fs`
2. `AWS_ENDPOINT_URL_S3`
3. `AWS_ENDPOINT_URL`
4. the active AWS profile from `AWS_CONFIG_FILE` or `~/.aws/config`

Profile selection follows `AWS_PROFILE`, then `AWS_DEFAULT_PROFILE`, then `default`, and resolves exactly one active profile. If an explicitly selected profile has no endpoint, the resolver returns no override instead of falling through to another profile whose credentials are not active.

The selected profile supports profile-level `endpoint_url`, service-section S3 endpoints, and nested S3 endpoint configuration. Missing, malformed, or undecodable config files are ignored. AWS config is read as UTF-8 with interpolation disabled so percent-encoded endpoint URLs remain intact.

For local Java jobs, a resolved custom endpoint is also passed as the Hadoop S3A endpoint with path-style access enabled.

Fixes #2087.

## Validation

Merged current `dev` (`2073060`) into the PR branch, then ran from `user_tools`:

- `PYTHONPATH=src .venv/bin/python -m pytest tests/spark_rapids_tools_ut/test_csppath.py -q` — 21 passed
- `PYTHONPATH=src .venv/bin/python -m pytest tests/spark_rapids_tools_ut/test_csppath.py tests/spark_rapids_tools_ut/test_cluster.py -q` — 28 passed
- Pylint on the parser and regression tests — 10.00/10
- Flake8 on the parser and regression tests
- `py_compile` on the parser
- `git diff --check upstream/dev...HEAD`
