### PR TITLE
Preserve configured memory sentinel values in AutoTuner

### DIFF
--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -411,6 +411,8 @@ tuningDefinitions:
     confType:
       name: byte
       defaultUnit: Byte
+    specialValues:
+      - "-1"
   - label: spark.sql.files.maxPartitionBytes
     description: >-
       The maximum number of bytes to pack into a single partition when reading files.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntry.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, NVIDIA CORPORATION.
+ * Copyright (c) 2025-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,6 +126,10 @@ class MemoryUnitTuningEntry(
     definition: Option[TuningEntryDefinition] = None)
   extends TuningEntryBase(name, originalValueRaw, tunedValueRaw, definition) {
 
+  private def isSpecialValue(value: String): Boolean = {
+    definition.exists(_.isSpecialValue(value))
+  }
+
   /**
    * Parse the default memory unit from the tuning table and store it as a ByteUnit value.
    * E.g. "MiB" -> ByteUnit.MiB
@@ -160,8 +164,12 @@ class MemoryUnitTuningEntry(
    * @return The normalized string with bytes unit (e.g. "1024b")
    */
   override def normalizeValue(propValue: String): String = {
-    val bytes = StringUtils.convertMemorySizeToBytes(propValue, Some(defaultMemoryUnit))
-    s"${bytes}b"
+    if (isSpecialValue(propValue)) {
+      propValue
+    } else {
+      val bytes = StringUtils.convertMemorySizeToBytes(propValue, Some(defaultMemoryUnit))
+      s"${bytes}b"
+    }
   }
 
   /**
@@ -172,9 +180,13 @@ class MemoryUnitTuningEntry(
    * @return The formatted string with appropriate unit (e.g. "1KiB")
    */
   override def formatOutput(propValue: String): String = {
-    // Remove the 'b' suffix and convert to bytes
-    val bytes = propValue.dropRight(1).toLong
-    StringUtils.convertBytesToLargestUnit(bytes)
+    if (isSpecialValue(propValue)) {
+      propValue
+    } else {
+      // Remove the 'b' suffix and convert to bytes
+      val bytes = propValue.dropRight(1).toLong
+      StringUtils.convertBytesToLargestUnit(bytes)
+    }
   }
 
   init()

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/config/TuningEntryDefinition.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/config/TuningEntryDefinition.scala
@@ -119,6 +119,7 @@ object ConfType {
  *                   track which plugin modified property.
  * @param confType A map containing the configuration type information with optional default unit
  *                 Example: { "name": "byte", "defaultUnit": "MiB" } or { "name": "string" }
+ * @param specialValues Values that should bypass type-specific normalization and formatting.
  * @param comments The defaults comments to be loaded for the entry. It is a map to represent
  *                 three different types of comments:
  *                 1. "missing" to represent the default comment to be appended to the AutoTuner's
@@ -138,6 +139,7 @@ class TuningEntryDefinition(
     @BeanProperty var defaultSpark: String,
     @BeanProperty var modifiedBy: String,
     @BeanProperty var confType: util.LinkedHashMap[String, String],
+    @BeanProperty var specialValues: util.List[String],
     @BeanProperty var comments: util.LinkedHashMap[String, String]) {
   private lazy val confTypeInfo: ConfType = ConfType.fromMap(confType)
   private lazy val categoryEnum: CategoryEnum.Value = CategoryEnum.fromString(category)
@@ -154,6 +156,7 @@ class TuningEntryDefinition(
       defaultSpark = null,
       modifiedBy = "",
       confType = new util.LinkedHashMap[String, String](),
+      specialValues = new util.ArrayList[String](),
       comments = new util.LinkedHashMap[String, String]())
   }
 
@@ -186,6 +189,10 @@ class TuningEntryDefinition(
 
   def getLevelAsEnum: LevelEnum.Value = {
     levelEnum
+  }
+
+  def isSpecialValue(value: String): Boolean = {
+    Option(specialValues).exists(_.asScala.contains(value))
   }
 
   /**
@@ -251,6 +258,7 @@ object TuningEntryDefinition {
    * @param bootstrapEntry whether this should be a bootstrap entry (default: true)
    * @param defaultSpark the default Spark value (default: null)
    * @param modifiedBy the plugin(s) that modified this entry (default: "")
+   * @param specialValues values that bypass type-specific normalization and formatting
    * @return a new TuningEntryDefinition instance
    */
   def apply(
@@ -263,7 +271,8 @@ object TuningEntryDefinition {
       category: CategoryEnum.Value = CategoryEnum.Tuning,
       bootstrapEntry: Boolean = true,
       defaultSpark: String = null,
-      modifiedBy: String = ""): TuningEntryDefinition = {
+      modifiedBy: String = "",
+      specialValues: Seq[String] = Seq.empty): TuningEntryDefinition = {
     // Create a new TuningEntryDefinition with the provided parameters.
     val defn = new TuningEntryDefinition()
     defn.setLabel(label)
@@ -274,6 +283,7 @@ object TuningEntryDefinition {
     defn.setBootstrapEntry(bootstrapEntry)
     defn.setDefaultSpark(defaultSpark)
     defn.setModifiedBy(modifiedBy)
+    defn.setSpecialValues(new util.ArrayList[String](specialValues.asJava))
     // Create the confType map with the provided confType and optional defaultUnit.
     val confTypeMap = Map("name" -> confType.toString) ++ defaultUnit.map("defaultUnit" -> _)
     defn.setConfType(new java.util.LinkedHashMap(confTypeMap.asJava))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -123,6 +123,19 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     assertExpectedLinesExist(expectedResults, autoTunerOutput)
   }
 
+  test("test AutoTuner for Qualification preserves disabled AQE broadcast threshold") {
+    val autoTuner = buildDefaultAutoTuner(
+      defaultSparkProps ++ mutable.Map(
+        "spark.sql.adaptive.autoBroadcastJoinThreshold" -> "-1"))
+    val (properties, comments) = autoTuner.getRecommendedProperties(showOnlyUpdatedProps =
+      QualificationAutoTunerRunner.filterByUpdatedPropsEnabled)
+    val output = Profiler.getAutoTunerResultsAsString(properties, comments)
+
+    assertExpectedLinesExist(
+      Seq("--conf spark.sql.adaptive.autoBroadcastJoinThreshold=-1"),
+      output)
+  }
+
   // scalastyle:off line.size.limit
   val testData: TableFor3[String, String, Seq[String]] = Table(
     ("testName", "workerMemory", "expectedResults"),

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntrySuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntrySuite.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.tuning
+
+import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, TuningEntryDefinition}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers._
+
+import org.apache.spark.sql.rapids.tool.InvalidMemoryUnitFormatException
+
+class TuningEntrySuite extends AnyFunSuite {
+  private def memoryDefinition(
+      specialValues: Seq[String]): TuningEntryDefinition = {
+    TuningEntryDefinition(
+      label = "test.memory",
+      confType = ConfTypeEnum.Byte,
+      defaultUnit = Some("Byte"),
+      specialValues = specialValues)
+  }
+
+  test("memory entry preserves a declared special value") {
+    val entry = TuningEntry.build(
+      "test.memory", Some("-1"), None, Some(memoryDefinition(Seq("-1"))))
+    entry.getOriginalValue shouldBe Some("-1")
+  }
+
+  test("memory entry normalizes negative one when it is not declared special") {
+    val entry = TuningEntry.build(
+      "test.memory", Some("-1"), None, Some(memoryDefinition(Seq.empty)))
+    entry.getOriginalValue shouldBe Some("-1b")
+  }
+
+  test("memory entry rejects an undeclared negative value") {
+    an[InvalidMemoryUnitFormatException] should be thrownBy {
+      TuningEntry.build(
+        "test.memory", Some("-2g"), None, Some(memoryDefinition(Seq("-1"))))
+    }
+  }
+
+  test("AQE broadcast threshold declares negative one as special") {
+    val definition = TuningEntryDefinition
+      .getEntryDefinition("spark.sql.adaptive.autoBroadcastJoinThreshold").get
+    definition.isSpecialValue("-1") shouldBe true
+  }
+}


### PR DESCRIPTION
Fixes #2112

### Problem

AutoTuner currently normalizes `spark.sql.adaptive.autoBroadcastJoinThreshold=-1` to `-1b`, which is then rejected as an invalid memory value. This change lets memory tuning definitions declare property-specific special values, so the valid Spark sentinel remains `-1` without changing generic memory parsing.

AutoTuner handles declared special values such as `-1` correctly whether they come from the existing configuration or a new recommendation. It outputs `-1` unchanged instead of converting it to `-1b`.

### Approach

- Add optional `specialValues` metadata to `TuningEntryDefinition`.
- Declare `"-1"` only for `spark.sql.adaptive.autoBroadcastJoinThreshold`.
- Have `MemoryUnitTuningEntry` bypass normalization and output formatting only for values declared by that property's definition.
- Apply the same normalization path to generated recommendations, allowing AutoTuner to tune either to or from a declared special value.
- Keep all other memory values on the existing parsing and formatting path.

### Key design decisions

- Sentinel meaning stays with tuning configuration metadata because `-1` is not a universal memory value.
- `StringUtils` remains configuration-agnostic.
- The no-argument `TuningEntryDefinition` constructor uses an empty Java list, preserving SnakeYAML loading for existing entries without `specialValues`.

### Testing

- `TuningEntrySuite`: covers declared `-1`, undeclared `-1`, invalid `-2g`, and YAML metadata.
- `QualificationAutoTunerSuite`: verifies generated output contains `--conf spark.sql.adaptive.autoBroadcastJoinThreshold=-1`.
