### PR TITLE
Recommend the RAPIDS cache serializer for cached SQL plans

### DIFF
--- a/core/src/main/resources/bootstrap/tuningConfigs.yaml
+++ b/core/src/main/resources/bootstrap/tuningConfigs.yaml
@@ -277,6 +277,12 @@ default:
     max: 512m
     usedBy: spark.kryoserializer.buffer.max
 
+  - name: CACHE_SERIALIZER
+    description: >-
+      Serializer used for Spark SQL cached batches on the GPU
+    default: com.nvidia.spark.ParquetCachedBatchSerializer
+    usedBy: spark.sql.cache.serializer
+
   - name: LOCALITY_WAIT
     description: >-
       Time to wait to launch a data-local task before giving up and launching

--- a/core/src/main/resources/bootstrap/tuningTable.yaml
+++ b/core/src/main/resources/bootstrap/tuningTable.yaml
@@ -327,6 +327,19 @@ tuningDefinitions:
     category: tuning
     confType:
       name: string
+  - label: spark.sql.cache.serializer
+    description: >-
+      Serializer used for Spark SQL cached batches.
+    enabled: true
+    level: job
+    category: functionality
+    bootstrapEntry: true
+    defaultSpark: org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer
+    confType:
+      name: string
+    comments:
+      missing: enables GPU processing of Spark SQL cached batches.
+      updated: replacing Spark's default cache serializer enables GPU processing of cached batches.
   - label: spark.shuffle.manager
     description: >-
       The RAPIDS Shuffle Manager is an implementation of the ShuffleManager interface in Apache Spark that

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   override def getRedundantReadSize: Long = 0
   override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = None
   override def getClassPathEntries: Map[String, String] = Map[String, String]()
+  def hasSqlCacheEvidence: Boolean = false
 }
 
 

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -128,6 +128,7 @@ class SingleAppSummaryInfoProvider(
 
   private lazy val distinctLocations = app.dsInfo.groupBy(_.location)
   override def isAppInfoAvailable: Boolean = Option(app).isDefined
+  override def hasSqlCacheEvidence: Boolean = appInfo.hasSqlCacheEvidence
 
   private def findPropertyInProfPropertyResults(
       key: String,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1331,12 +1331,53 @@ abstract class AutoTuner(
     // Recommend shuffle partitions here.
     // Note that this may get overridden if AQE is enabled.
     recommendShufflePartitions()
+    recommendCacheSerializer()
     recommendKryoSerializerSetting()
     recommendGCProperty()
     if (platform.requirePathRecommendations) {
       recommendClassPathEntries()
     }
     recommendSystemProperties()
+  }
+
+  private def recommendCacheSerializer(): Unit = {
+    val propertyKey = AutoTuner.CACHE_SERIALIZER_PROPERTY
+    if (appInfoProvider.hasSqlCacheEvidence && !skippedRecommendations.contains(propertyKey)) {
+      val gpuCacheScanDisabled = getPropertyValue(AutoTuner.IN_MEMORY_TABLE_SCAN_PROPERTY)
+        .exists(_.trim.equalsIgnoreCase("false"))
+      if (gpuCacheScanDisabled) {
+        appendComment(propertyKey,
+          s"is not recommended because '${AutoTuner.IN_MEMORY_TABLE_SCAN_PROPERTY}' is disabled, " +
+            "so GPU cache scans remain disabled.")
+      } else {
+        AutoTuner.getCacheSerializerDefinition(finalTuningTable).foreach { tuningDefinition =>
+          val recommendedSerializer = configProvider
+            .getEntry(AutoTuner.CACHE_SERIALIZER_CONFIG).getDefault
+          val sparkDefault = tuningDefinition.getDefaultSpark
+
+          getPropertyValue(propertyKey) match {
+            case Some(current) if current == recommendedSerializer => ()
+            case Some(current) if platform.isPropertyUserOverridden(propertyKey) =>
+              appendComment(propertyKey,
+                s"is fixed by target cluster configuration to '$current'; preserving it. " +
+                  s"'$recommendedSerializer' is required for GPU InMemoryTableScan.")
+            case Some(current) if current != sparkDefault =>
+              // Preserve explicit custom serializers and surface the compatibility requirement.
+              appendComment(propertyKey,
+                s"uses custom cache serializer '$current'; preserving it. " +
+                  s"'$recommendedSerializer' is required for GPU InMemoryTableScan.")
+            case _ =>
+              appendRecommendation(propertyKey, recommendedSerializer)
+          }
+
+          if (appInfoProvider.getSparkVersion.exists(AutoTuner.hasAqeCacheScanFallback)) {
+            appendComment(propertyKey,
+              "remains compatible, but Spark 3.5.0 and 3.5.1 disable GPU InMemoryTableScan " +
+                "under AQE, so cached scans may remain on the CPU.")
+          }
+        }
+      }
+    }
   }
 
   // if the user set the serializer to use Kryo, make sure we recommend using the GPU version
@@ -2172,6 +2213,21 @@ abstract class AutoTuner(
 }
 
 object AutoTuner {
+  private[tuning] val CACHE_SERIALIZER_PROPERTY = "spark.sql.cache.serializer"
+  private[tuning] val CACHE_SERIALIZER_CONFIG = "CACHE_SERIALIZER"
+  private[tuning] val IN_MEMORY_TABLE_SCAN_PROPERTY =
+    "spark.rapids.sql.exec.InMemoryTableScanExec"
+
+  private[tuning] def hasAqeCacheScanFallback(sparkVersion: String): Boolean = {
+    ToolUtils.compareVersions(sparkVersion, "3.5.0").exists(_ >= 0) &&
+      ToolUtils.compareVersions(sparkVersion, "3.5.2").exists(_ < 0)
+  }
+
+  private[tuning] def getCacheSerializerDefinition(
+      tuningTable: Map[String, TuningEntryDefinition]): Option[TuningEntryDefinition] = {
+    tuningTable.get(CACHE_SERIALIZER_PROPERTY)
+  }
+
   /**
    * Helper function to get a combined property function that can be used
    * to retrieve the value of a property in the following priority order:

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
@@ -68,6 +68,8 @@ class QualAppSummaryInfoProvider(
     Option(appInfo.sparkVersion)
   }
 
+  override def hasSqlCacheEvidence: Boolean = appInfo.hasSqlCacheEvidence
+
   def getAppID: String = appInfo.appId
 
   override def getJvmGCFractions: Seq[Double] = {

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -151,6 +151,8 @@ abstract class AppBase(
 
   def sqlPlans: immutable.Map[Long, SparkPlanInfo] = sqlManager.getPlanInfos
 
+  def hasSqlCacheEvidence: Boolean = sqlManager.hasSqlCacheEvidence
+
   def getStageIDsFromAccumIds(accumIds: Seq[Long]): Set[Int] = {
     accumIds.flatMap(accumManager.getAccStageIds).toSet
   }
@@ -262,6 +264,7 @@ abstract class AppBase(
   }
 
   def getOrCreateStage(info: StageInfo): StageModel = {
+    sqlManager.collectObservedRDDScopes(info.rddInfos)
     val stage = stageManager.addStageInfo(info)
     stage
   }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManager.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import scala.collection.{immutable, mutable}
 
 import org.apache.spark.sql.rapids.tool.{AccumToStageRetriever, AppBase}
 import org.apache.spark.sql.rapids.tool.util.stubs.SparkPlanInfo
+import org.apache.spark.storage.RDDInfo
 
 // This SparkPlanInfoTruncated is used to trim and serialize
 // SparkPlanInfo by removing the unnecessary fields. Only three fields are kept:
@@ -62,6 +63,17 @@ object SparkPlanInfoTruncated {
   }
 }
 
+object SQLPlanModelManager {
+  private val SQL_CACHE_NODE_NAMES =
+    Set("InMemoryRelation", "InMemoryTableScan", "TableCacheQueryStage", "GpuInMemoryTableScan")
+  private val NAMED_CACHE_SCAN_PREFIX = "Scan In-memory table "
+
+  private[store] def isSqlCacheNode(nodeName: String): Boolean = {
+    nodeName != null &&
+      (SQL_CACHE_NODE_NAMES.contains(nodeName) || nodeName.startsWith(NAMED_CACHE_SCAN_PREFIX))
+  }
+}
+
 /**
  * Container class to store the information about SqlPlans.
  * @param appInst the instance of AppBase where the SQLPlanModelManager belongs to. This is used to
@@ -71,6 +83,32 @@ object SparkPlanInfoTruncated {
 class SQLPlanModelManager(appInst: AppBase) {
   // SortedMap is used to keep the order of the sqlPlans by Id
   val sqlPlans: mutable.SortedMap[Long, SQLPlanModel] = mutable.SortedMap[Long, SQLPlanModel]()
+  // Keep bounded evidence from every observed version, including plans discarded after AQE.
+  private var observedSqlCache = false
+
+  /** Returns whether a SQL cache operator was observed in any plan version or RDD scope. */
+  def hasSqlCacheEvidence: Boolean = observedSqlCache
+
+  private def containsSqlCacheNode(planInfo: SparkPlanInfo): Boolean = {
+    SQLPlanModelManager.isSqlCacheNode(planInfo.nodeName) ||
+      planInfo.children.exists(containsSqlCacheNode)
+  }
+
+  private def collectSqlCacheEvidence(planInfo: SparkPlanInfo): Unit = {
+    if (!observedSqlCache) {
+      observedSqlCache = containsSqlCacheNode(planInfo)
+    }
+  }
+
+  /** Records SQL cache operators retained in stage RDD scopes but omitted from SQL plan events. */
+  def collectObservedRDDScopes(rddInfos: Seq[RDDInfo]): Unit = {
+    if (!observedSqlCache) {
+      observedSqlCache = rddInfos.iterator
+        .flatMap(_.scope.toSeq)
+        .flatMap(_.getAllScopes)
+        .exists(scope => SQLPlanModelManager.isSqlCacheNode(scope.name))
+    }
+  }
 
   /**
    * Get the SparkPlanInfo for the given executionId. This is the last plan version added to that
@@ -118,6 +156,7 @@ class SQLPlanModelManager(appInst: AppBase) {
     //  information of an SqlPlan (i.e., startTime,..etc))
     val planModel = sqlPlans.getOrElseUpdate(id, new SQLPlanModelPrimaryWithDSCaching(id, appInst))
     planModel.addPlan(planInfo, physicalDescription)
+    collectSqlCacheEvidence(planModel.planInfo)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/AppSummaryInfoProviderSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/AppSummaryInfoProviderSuite.scala
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.tuning
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import com.nvidia.spark.rapids.BaseNoSparkSuite
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogPathProcessor,
+  PlatformFactory, PlatformNames, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.analysis.AggRawMetricsResult
+import com.nvidia.spark.rapids.tool.profiling.{AppInfoProfileResults, ApplicationSummaryInfo,
+  RapidsPropertyProfileResult, SingleAppSummaryInfoProvider, SQLPlanInfoProfileResult}
+import com.nvidia.spark.rapids.tool.tuning.config.{ProfTuningConfigProvider, TuningConfigProvider}
+import org.scalatest.matchers.should.Matchers._
+
+import org.apache.spark.sql.TrampolineUtil
+import org.apache.spark.sql.execution.{SparkPlanInfo => UpstreamSparkPlanInfo}
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.store.SparkPlanInfoTruncated
+import org.apache.spark.sql.rapids.tool.util.{RapidsToolsConfUtil, SparkRuntime}
+
+class AppSummaryInfoProviderSuite extends BaseNoSparkSuite {
+
+  private val cacheSerializerProperty = AutoTuner.CACHE_SERIALIZER_PROPERTY
+
+  private val sparkProperties = Map(
+    "spark.master" -> "yarn",
+    "spark.executor.cores" -> "8",
+    "spark.executor.instances" -> "2",
+    "spark.executor.memory" -> "16g",
+    "spark.dynamicAllocation.enabled" -> "false")
+
+  private val emptyAggMetrics = AggRawMetricsResult(
+    Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty, Seq.empty)
+
+  private def plan(name: String, children: UpstreamSparkPlanInfo*): UpstreamSparkPlanInfo = {
+    new UpstreamSparkPlanInfo(name, name, children, Map.empty, Seq.empty)
+  }
+
+  private def addPlanVersions(app: org.apache.spark.sql.rapids.tool.AppBase): Unit = {
+    app.sqlManager.addNewExecution(1L, plan("Project"), "primary")
+    app.sqlManager.addAQE(1L,
+      plan("AdaptiveSparkPlan", plan("InMemoryTableScan", plan("InMemoryRelation"))),
+      "aqe-cache")
+    app.sqlManager.addAQE(1L, plan("Project"), "aqe-final")
+  }
+
+  private def emptySummary(
+      sqlPlanInfo: Seq[SQLPlanInfoProfileResult] = Seq.empty): ApplicationSummaryInfo = {
+    val summarySparkProperties = sparkProperties.toSeq.map { case (key, value) =>
+      RapidsPropertyProfileResult(key, Array(key, value))
+    }
+    ApplicationSummaryInfo(
+      appInfo = Seq(AppInfoProfileResults(
+        appName = "ProviderTest",
+        appId = Some("local-provider-test"),
+        attemptId = None,
+        sparkUser = "test",
+        startTime = 100000L,
+        endTime = Some(200000L),
+        duration = Some(100000L),
+        durationStr = "1m 40s",
+        sparkRuntime = SparkRuntime.SPARK_RAPIDS,
+        sparkVersion = "3.5.0",
+        pluginEnabled = true,
+        totalCoreSeconds = 0L)),
+      dsInfo = Seq.empty,
+      execInfo = Seq.empty,
+      jobInfo = Seq.empty,
+      rapidsProps = Seq.empty,
+      rapidsJar = Seq.empty,
+      sqlMetrics = Seq.empty,
+      stageMetrics = Seq.empty,
+      jobAggMetrics = Seq.empty,
+      stageAggMetrics = Seq.empty,
+      sqlTaskAggMetrics = Seq.empty,
+      durAndCpuMet = Seq.empty,
+      skewInfo = Seq.empty,
+      failedTasks = Seq.empty,
+      failedStages = Seq.empty,
+      failedJobs = Seq.empty,
+      removedBMs = Seq.empty,
+      removedExecutors = Seq.empty,
+      unsupportedOps = Seq.empty,
+      sparkProps = summarySparkProperties,
+      sqlStageInfo = Seq.empty,
+      wholeStage = Seq.empty,
+      appLogPath = Seq.empty,
+      ioMetrics = Seq.empty,
+      sysProps = Seq.empty,
+      sqlCleanedAlignedIds = Seq.empty,
+      sparkRapidsBuildInfo = Seq.empty,
+      writeOpsInfo = Seq.empty,
+      sqlPlanInfo = sqlPlanInfo)
+  }
+
+  private def cacheSerializerRecommendation(
+      provider: AppSummaryInfoBaseProvider,
+      helper: AutoTunerHelper,
+      excludedProperties: List[String] = List.empty): Option[String] = {
+    val targetCluster = if (excludedProperties.nonEmpty) {
+      Some(ToolTestUtils.buildTargetClusterInfo(excludeSparkProperties = excludedProperties))
+    } else {
+      None
+    }
+    val platform = PlatformFactory.createInstance(PlatformNames.EMR, targetCluster)
+    platform.configureClusterInfoFromEventLog(
+      coresPerExecutor = 8,
+      execsPerNode = 1,
+      numExecs = 2,
+      numExecutorNodes = 2,
+      sparkProperties,
+      systemProperties = Map.empty)
+    val (recommendations, _) = helper.buildAutoTunerFromProps(provider, platform)
+      .getRecommendedProperties(showOnlyUpdatedProps = false)
+    recommendations.find(_.name == cacheSerializerProperty).map(_.getTuneValue())
+  }
+
+  private def configuredCacheSerializer: String = {
+    TuningConfigProvider.builder.build[ProfTuningConfigProvider]
+      .getEntry(AutoTuner.CACHE_SERIALIZER_CONFIG).getDefault
+  }
+
+  private def withMinimalEventLog(f: String => Unit): Unit = {
+    withMinimalEventLog(Seq.empty)(f)
+  }
+
+  private def withMinimalEventLog(
+      extraEvents: Seq[String])(f: String => Unit): Unit = {
+    val events = Seq(
+      """{"Event":"SparkListenerLogStart","Spark Version":"3.5.0"}""",
+      """{"Event":"SparkListenerApplicationStart","App Name":"ProviderTest",""" +
+        """"App ID":"local-provider-test","Timestamp":100000,"User":"test"}""") ++
+      extraEvents ++ Seq(
+      """{"Event":"SparkListenerApplicationEnd","Timestamp":200000}""")
+    TrampolineUtil.withTempDir { tempDir =>
+      val eventLog = Paths.get(tempDir.getAbsolutePath, "eventlog")
+      Files.write(eventLog, events.mkString("\n").getBytes(StandardCharsets.UTF_8))
+      f(eventLog.toString)
+    }
+  }
+
+  private def stageSubmittedWithScope(scopeName: String): String = {
+    s"""{"Event":"SparkListenerStageSubmitted","Stage Info":{"Stage ID":0,""" +
+      s""""Stage Attempt ID":0,"Stage Name":"cache stage","Number of Tasks":1,""" +
+      s""""RDD Info":[{"RDD ID":0,"Name":"MapPartitionsRDD",""" +
+      s""""Scope":"{\\"id\\":\\"1\\",\\"name\\":\\"$scopeName\\"}",""" +
+      s""""Callsite":"count","Parent IDs":[],"Storage Level":{"Use Disk":false,""" +
+      s""""Use Memory":false,"Deserialized":false,"Replication":1},"Barrier":false,""" +
+      s""""Number of Partitions":1,"Number of Cached Partitions":0,"Memory Size":0,""" +
+      s""""Disk Size":0}],"Parent IDs":[],"Details":"","Submission Time":110000,""" +
+      s""""Accumulables":[],"Resource Profile Id":0},"Properties":{}}"""
+  }
+
+  test("qualification provider exposes cache nodes observed only in an AQE plan") {
+    withMinimalEventLog { eventLog =>
+      val app = createAppFromEventlog(eventLog)
+      app.sparkProperties ++= sparkProperties
+      addPlanVersions(app)
+      val provider = new QualAppSummaryInfoProvider(
+        app, None, emptyAggMetrics, Seq.empty)
+
+      provider.hasSqlCacheEvidence shouldBe true
+      cacheSerializerRecommendation(provider, QualificationAutoTunerHelper) shouldBe
+        Some(configuredCacheSerializer)
+    }
+  }
+
+  test("profiling provider uses observed plans without changing the PRE-AQE summary") {
+    withMinimalEventLog { eventLog =>
+      val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+      val eventLogInfo = EventLogPathProcessor.getEventLogInfo(eventLog, hadoopConf).head._1
+      val app = new ApplicationInfo(hadoopConf, eventLogInfo)
+      addPlanVersions(app)
+      val primaryPlan = SparkPlanInfoTruncated("Project", "Project", Seq.empty)
+      val summary = emptySummary(Seq(SQLPlanInfoProfileResult(1L, primaryPlan)))
+      val provider = new SingleAppSummaryInfoProvider(app, summary)
+
+      summary.sqlPlanInfo.map(_.sparkPlanInfo.nodeName) shouldBe Seq("Project")
+      provider.hasSqlCacheEvidence shouldBe true
+      cacheSerializerRecommendation(provider, ProfilingAutoTunerHelper) shouldBe
+        Some(configuredCacheSerializer)
+    }
+  }
+
+  test("providers expose cache nodes observed only in stage RDD scopes") {
+    withMinimalEventLog(Seq(stageSubmittedWithScope("TableCacheQueryStage"))) { eventLog =>
+      val qualApp = createAppFromEventlog(eventLog)
+      qualApp.sparkProperties ++= sparkProperties
+      val qualProvider = new QualAppSummaryInfoProvider(
+        qualApp, None, emptyAggMetrics, Seq.empty)
+
+      val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+      val eventLogInfo = EventLogPathProcessor.getEventLogInfo(eventLog, hadoopConf).head._1
+      val profApp = new ApplicationInfo(hadoopConf, eventLogInfo)
+      val profProvider = new SingleAppSummaryInfoProvider(profApp, emptySummary())
+
+      qualProvider.hasSqlCacheEvidence shouldBe true
+      profProvider.hasSqlCacheEvidence shouldBe true
+      cacheSerializerRecommendation(provider = qualProvider, QualificationAutoTunerHelper) shouldBe
+        Some(configuredCacheSerializer)
+      cacheSerializerRecommendation(provider = profProvider, ProfilingAutoTunerHelper) shouldBe
+        Some(configuredCacheSerializer)
+    }
+  }
+
+  test("providers expose no cache evidence when no cache node was observed") {
+    withMinimalEventLog(Seq(stageSubmittedWithScope("mapPartitions"))) { eventLog =>
+      val qualApp = createAppFromEventlog(eventLog)
+      qualApp.sparkProperties ++= sparkProperties
+      qualApp.sqlManager.addNewExecution(1L, plan("Project", plan("Filter")), "primary")
+      val qualProvider = new QualAppSummaryInfoProvider(
+        qualApp, None, emptyAggMetrics, Seq.empty)
+
+      val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+      val eventLogInfo = EventLogPathProcessor.getEventLogInfo(eventLog, hadoopConf).head._1
+      val profApp = new ApplicationInfo(hadoopConf, eventLogInfo)
+      profApp.sqlManager.addNewExecution(1L, plan("Project", plan("Filter")), "primary")
+      val profProvider = new SingleAppSummaryInfoProvider(profApp, emptySummary())
+
+      qualProvider.hasSqlCacheEvidence shouldBe false
+      profProvider.hasSqlCacheEvidence shouldBe false
+      cacheSerializerRecommendation(qualProvider, QualificationAutoTunerHelper) shouldBe None
+      cacheSerializerRecommendation(profProvider, ProfilingAutoTunerHelper) shouldBe None
+    }
+  }
+
+  test("cache serializer exclusion is honored when cache nodes were observed") {
+    withMinimalEventLog { eventLog =>
+      val app = createAppFromEventlog(eventLog)
+      app.sparkProperties ++= sparkProperties
+      addPlanVersions(app)
+      val provider = new QualAppSummaryInfoProvider(
+        app, None, emptyAggMetrics, Seq.empty)
+
+      cacheSerializerRecommendation(
+        provider,
+        QualificationAutoTunerHelper,
+        excludedProperties = List(cacheSerializerProperty)) shouldBe None
+    }
+  }
+
+  test("providers recommend cache serializer from a Spark-generated named cache plan") {
+    TrampolineUtil.withTempDir { eventLogDir =>
+      val (eventLog, _) = ToolTestUtils.generateEventLog(eventLogDir, "named-cache") { spark =>
+        val source = spark.range(100).selectExpr("id AS customer_id", "id * 10 AS total")
+        source.createOrReplaceTempView("hot_orders")
+        spark.catalog.cacheTable("hot_orders")
+        spark.table("hot_orders").count()
+        val cachedQuery = spark.sql("SELECT customer_id FROM hot_orders WHERE total > 100")
+        cachedQuery.count()
+        cachedQuery
+      }
+      val qualApp = createAppFromEventlog(eventLog)
+      qualApp.sparkProperties ++= sparkProperties
+      def collectNodeNames(
+          plan: org.apache.spark.sql.rapids.tool.util.stubs.SparkPlanInfo): Seq[String] = {
+        plan.nodeName +: plan.children.flatMap(collectNodeNames)
+      }
+      val nodeNames = qualApp.sqlManager.getPlanInfos.values.toSeq.flatMap(collectNodeNames)
+      withClue(s"Observed Spark plan nodes: ${nodeNames.mkString(", ")}") {
+        nodeNames should contain("Scan In-memory table hot_orders")
+      }
+      val qualProvider = new QualAppSummaryInfoProvider(
+        qualApp, None, emptyAggMetrics, Seq.empty)
+
+      val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+      val eventLogInfo = EventLogPathProcessor.getEventLogInfo(eventLog, hadoopConf).head._1
+      val profApp = new ApplicationInfo(hadoopConf, eventLogInfo)
+      val profProvider = new SingleAppSummaryInfoProvider(profApp, emptySummary())
+
+      qualProvider.hasSqlCacheEvidence shouldBe true
+      profProvider.hasSqlCacheEvidence shouldBe true
+      cacheSerializerRecommendation(qualProvider, QualificationAutoTunerHelper) shouldBe
+        Some(configuredCacheSerializer)
+      cacheSerializerRecommendation(profProvider, ProfilingAutoTunerHelper) shouldBe
+        Some(configuredCacheSerializer)
+    }
+  }
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -51,7 +51,8 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val shuffleSkewStages: Set[Long],
     val scanStagesWithGpuOomSet: Set[Long],
     val gpuShuffleStagesWithContainerOomSet: Set[Long],
-    val maxColumnarExchangeDataSizeBytes: Option[Long] = None)
+    val maxColumnarExchangeDataSizeBytes: Option[Long] = None,
+    val hasSqlCache: Boolean = false)
     extends BaseProfilingAppSummaryInfoProvider {
   override def isAppInfoAvailable = true
   override def getMaxInput: Double = maxInput
@@ -72,6 +73,7 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def scanStagesWithGpuOom: Set[Long] = scanStagesWithGpuOomSet
   override def gpuShuffleStagesWithContainerOom: Set[Long] = gpuShuffleStagesWithContainerOomSet
   override def getMaxColumnarExchangeDataSizeBytes: Option[Long] = maxColumnarExchangeDataSizeBytes
+  override def hasSqlCacheEvidence: Boolean = hasSqlCache
 
   /**
    * Sets the spark master property in the properties map.
@@ -137,11 +139,12 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
       shuffleSkewStages: Set[Long] = Set(),
       scanStagesWithGpuOom: Set[Long] = Set(),
       gpuShuffleStagesWithContainerOom: Set[Long] = Set(),
-      maxColumnarExchangeDataSizeBytes: Option[Long] = None): AppInfoProviderMockTest = {
+      maxColumnarExchangeDataSizeBytes: Option[Long] = None,
+      hasSqlCache: Boolean = false): AppInfoProviderMockTest = {
     new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
       sparkVersion, rapidsJars, distinctLocationPct, redundantReadSize, meanInput, meanShuffleRead,
       shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom,
-      gpuShuffleStagesWithContainerOom, maxColumnarExchangeDataSizeBytes)
+      gpuShuffleStagesWithContainerOom, maxColumnarExchangeDataSizeBytes, hasSqlCache)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -19,8 +19,10 @@ package com.nvidia.spark.rapids.tool.tuning
 import scala.collection.mutable
 
 import com.nvidia.spark.rapids.tool.{DynamicAllocationInfo, GpuTypes, NodeInstanceMapKey, PlatformFactory, PlatformInstanceTypes, PlatformNames, ToolTestUtils}
-import com.nvidia.spark.rapids.tool.profiling.Profiler
-import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, TuningConfigEntry, TuningEntryDefinition}
+import com.nvidia.spark.rapids.tool.profiling.{Profiler, RecommendedCommentResult}
+import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, TuningConfigEntry,
+  TuningConfiguration, TuningEntryDefinition}
+import org.scalatest.matchers.should.Matchers._
 
 import org.apache.spark.network.util.ByteUnit
 import org.apache.spark.sql.{SparkSession, TrampolineUtil}
@@ -41,12 +43,160 @@ import org.apache.spark.sql.rapids.tool.util.StringUtils
 @Since("25.04.2")
 class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
 
+  private val cacheSerializerProperty = AutoTuner.CACHE_SERIALIZER_PROPERTY
+  private val gpuCacheSerializer = "com.nvidia.spark.ParquetCachedBatchSerializer"
+  private val sparkCacheSerializer =
+    "org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer"
+
+  private def runCacheSerializerAutoTuner(
+      hasSqlCache: Boolean,
+      sourceSerializer: Option[String] = None,
+      tuningConfigs: Option[TuningConfiguration] = None,
+      targetClusterInfo: Option[TargetClusterProps] = None,
+      sourceProperties: Map[String, String] = Map.empty,
+      showOnlyUpdatedProps: Boolean = true,
+      sparkVersion: String = testSparkVersion):
+      (Seq[TuningEntryTrait], Seq[RecommendedCommentResult]) = {
+    val logEventsProps = mutable.LinkedHashMap(defaultDataprocProps.toSeq: _*)
+    logEventsProps ++= sourceProperties
+    sourceSerializer.foreach(logEventsProps.put(cacheSerializerProperty, _))
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0), logEventsProps,
+      Some(sparkVersion), hasSqlCache = hasSqlCache)
+    val platform = PlatformFactory.createInstance(PlatformNames.DATAPROC, targetClusterInfo)
+    configureEventLogClusterInfoForTest(platform, sparkProperties = logEventsProps.toMap)
+    buildAutoTunerForTests(infoProvider, platform,
+      userProvidedTuningConfigs = tuningConfigs)
+      .getRecommendedProperties(showOnlyUpdatedProps = showOnlyUpdatedProps)
+  }
+
+  private def cacheSerializerValue(properties: Seq[TuningEntryTrait]): Option[String] = {
+    properties.find(_.name == cacheSerializerProperty).map(_.getTuneValue())
+  }
+
   lazy val sparkSession: SparkSession = {
     SparkSession
       .builder()
       .master("local[*]")
       .appName("Rapids Spark Profiling Tool Unit Tests")
       .getOrCreate()
+  }
+
+  test("cache serializer is recommended when SQL cache evidence was observed") {
+    val (properties, _) = runCacheSerializerAutoTuner(hasSqlCache = true)
+
+    cacheSerializerValue(properties) shouldBe Some(gpuCacheSerializer)
+  }
+
+  test("cache serializer is not recommended without a cache plan node") {
+    val (properties, _) = runCacheSerializerAutoTuner(hasSqlCache = false)
+
+    cacheSerializerValue(properties) shouldBe None
+  }
+
+  test("Spark default cache serializer is replaced") {
+    val (properties, _) = runCacheSerializerAutoTuner(
+      hasSqlCache = true, Some(sparkCacheSerializer))
+
+    cacheSerializerValue(properties) shouldBe Some(gpuCacheSerializer)
+  }
+
+  test("configured cache serializer is preserved") {
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true, Some(gpuCacheSerializer))
+
+    cacheSerializerValue(properties) shouldBe None
+    comments.map(_.comment).exists(_.contains("custom cache serializer")) shouldBe false
+  }
+
+  test("custom cache serializer is preserved with an advisory") {
+    val customSerializer = "example.ExistingCachedBatchSerializer"
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true, Some(customSerializer))
+    val commentText = comments.map(_.comment).mkString("\n")
+
+    cacheSerializerValue(properties) shouldBe None
+    commentText should include("custom cache serializer")
+    commentText should include("preserving")
+    commentText should include("GPU InMemoryTableScan")
+  }
+
+  test("cache serializer recommendation uses the tuning configuration") {
+    val customSerializer = "example.CustomCachedBatchSerializer"
+    val tuningConfigs = ToolTestUtils.buildTuningConfigs(default = List(
+      TuningConfigEntry(
+        name = AutoTuner.CACHE_SERIALIZER_CONFIG,
+        default = customSerializer,
+        usedBy = cacheSerializerProperty)))
+    val (properties, _) = runCacheSerializerAutoTuner(
+      hasSqlCache = true, tuningConfigs = Some(tuningConfigs))
+
+    cacheSerializerValue(properties) shouldBe Some(customSerializer)
+  }
+
+  test("preserved Spark cache serializer retains the compatibility advisory") {
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      preserveSparkProperties = List(cacheSerializerProperty))
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true,
+      sourceSerializer = Some(sparkCacheSerializer),
+      targetClusterInfo = Some(targetClusterInfo))
+
+    cacheSerializerValue(properties) shouldBe Some(sparkCacheSerializer)
+    comments.map(_.comment).mkString("\n") should include("target cluster configuration")
+  }
+
+  test("missing preserved cache serializer is recommended") {
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      preserveSparkProperties = List(cacheSerializerProperty))
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true,
+      targetClusterInfo = Some(targetClusterInfo))
+
+    cacheSerializerValue(properties) shouldBe Some(gpuCacheSerializer)
+    comments.map(_.comment).mkString("\n") should not include "no source value"
+  }
+
+  test("enforced Spark cache serializer retains the compatibility advisory") {
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      enforcedSparkProperties = Map(cacheSerializerProperty -> sparkCacheSerializer))
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true,
+      targetClusterInfo = Some(targetClusterInfo),
+      showOnlyUpdatedProps = false)
+
+    cacheSerializerValue(properties) shouldBe Some(sparkCacheSerializer)
+    comments.map(_.comment).mkString("\n") should include("target cluster configuration")
+  }
+
+  test("disabled GPU cache scan suppresses serializer recommendation with an advisory") {
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true,
+      sourceProperties = Map(AutoTuner.IN_MEMORY_TABLE_SCAN_PROPERTY -> "false"))
+    val commentText = comments.map(_.comment).mkString("\n")
+
+    cacheSerializerValue(properties) shouldBe None
+    commentText should include(AutoTuner.IN_MEMORY_TABLE_SCAN_PROPERTY)
+    commentText should include("is not recommended")
+    commentText should include("GPU cache scans remain disabled")
+  }
+
+  test("Spark 3.5.1 cache serializer recommendation includes the AQE fallback advisory") {
+    val (properties, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true,
+      sparkVersion = "3.5.1")
+    val commentText = comments.map(_.comment).mkString("\n")
+
+    cacheSerializerValue(properties) shouldBe Some(gpuCacheSerializer)
+    commentText should include("disable GPU InMemoryTableScan under AQE")
+  }
+
+  test("Spark 3.5.2 cache serializer recommendation has no AQE fallback advisory") {
+    val (_, comments) = runCacheSerializerAutoTuner(
+      hasSqlCache = true,
+      sparkVersion = "3.5.2")
+
+    comments.map(_.comment).mkString("\n") should not include
+      "disable GPU InMemoryTableScan under AQE"
   }
 
   // Test that the properties from the custom target cluster props will be enforced.

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -27,6 +27,7 @@ import com.nvidia.spark.rapids.tool.tuning.config.{CategoryEnum, ConfTypeEnum, L
 import com.nvidia.spark.rapids.tool.views.CLUSTER_INFORMATION_LABEL
 import com.nvidia.spark.rapids.tool.views.qualification.QualReportGenConfProvider
 import org.scalatest.exceptions.TestFailedException
+import org.scalatest.matchers.should.Matchers._
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.TableFor3
 
@@ -57,10 +58,11 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
    * Helper method to return an instance of the Qualification AutoTuner with default properties
    */
   private def buildDefaultAutoTuner(
-      logEventsProps: mutable.Map[String, String] = defaultSparkProps): AutoTuner = {
+      logEventsProps: mutable.Map[String, String] = defaultSparkProps,
+      hasSqlCache: Boolean = false): AutoTuner = {
     val sparkPropsWithMemory = logEventsProps + ("spark.executor.memory" -> "212992MiB")
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
-      sparkPropsWithMemory, Some(testSparkVersion))
+      sparkPropsWithMemory, Some(testSparkVersion), hasSqlCache = hasSqlCache)
     val platform = PlatformFactory.createInstance(PlatformNames.EMR)
 
     // Configure cluster info: 32 cores, 5 workers, 4 GPUs per worker = 20 total executors
@@ -74,6 +76,43 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     )
 
     buildAutoTunerForTests(infoProvider, platform)
+  }
+
+  test("Qualification recommends cache serializer for InMemoryTableScan") {
+    val autoTuner = buildDefaultAutoTuner(hasSqlCache = true)
+    val (properties, _) = autoTuner.getRecommendedProperties(showOnlyUpdatedProps = false)
+
+    properties.find(_.name == AutoTuner.CACHE_SERIALIZER_PROPERTY).map(_.getTuneValue()) shouldBe
+      Some("com.nvidia.spark.ParquetCachedBatchSerializer")
+  }
+
+  test("Qualification preserves a custom cache serializer with an advisory") {
+    val customSerializer = "example.ExistingCachedBatchSerializer"
+    val logEventsProps =
+      defaultSparkProps + (AutoTuner.CACHE_SERIALIZER_PROPERTY -> customSerializer)
+    val autoTuner = buildDefaultAutoTuner(
+      logEventsProps, hasSqlCache = true)
+    val (properties, comments) =
+      autoTuner.getRecommendedProperties(showOnlyUpdatedProps = false)
+    val commentText = comments.map(_.comment).mkString("\n")
+
+    properties.find(_.name == AutoTuner.CACHE_SERIALIZER_PROPERTY).map(_.getTuneValue()) shouldBe
+      Some(customSerializer)
+    commentText should include("custom cache serializer")
+    commentText should include("preserving")
+    commentText should include("GPU InMemoryTableScan")
+  }
+
+  test("Qualification skips cache serializer when GPU cache scans are disabled") {
+    val logEventsProps = defaultSparkProps +
+      (AutoTuner.IN_MEMORY_TABLE_SCAN_PROPERTY -> "false")
+    val autoTuner = buildDefaultAutoTuner(logEventsProps, hasSqlCache = true)
+    val (properties, comments) = autoTuner.getRecommendedProperties()
+    val commentText = comments.map(_.comment).mkString("\n")
+
+    properties.find(_.name == AutoTuner.CACHE_SERIALIZER_PROPERTY) shouldBe None
+    commentText should include("is not recommended")
+    commentText should include(AutoTuner.IN_MEMORY_TABLE_SCAN_PROPERTY)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntrySuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/TuningEntrySuite.scala
@@ -16,7 +16,8 @@
 
 package com.nvidia.spark.rapids.tool.tuning
 
-import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, TuningEntryDefinition}
+import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, ProfTuningConfigProvider,
+  TuningConfigProvider, TuningEntryDefinition}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers._
 
@@ -55,5 +56,21 @@ class TuningEntrySuite extends AnyFunSuite {
     val definition = TuningEntryDefinition
       .getEntryDefinition("spark.sql.adaptive.autoBroadcastJoinThreshold").get
     definition.isSpecialValue("-1") shouldBe true
+  }
+
+  test("cache serializer configuration is loaded from YAML") {
+    val configProvider = TuningConfigProvider.builder.build[ProfTuningConfigProvider]
+    configProvider.getEntry(AutoTuner.CACHE_SERIALIZER_CONFIG).getDefault shouldBe
+      "com.nvidia.spark.ParquetCachedBatchSerializer"
+
+    val definition = TuningEntryDefinition
+      .getEntryDefinition(AutoTuner.CACHE_SERIALIZER_PROPERTY).get
+    definition.getDefaultSpark shouldBe
+      "org.apache.spark.sql.execution.columnar.DefaultCachedBatchSerializer"
+    definition.isBootstrap() shouldBe true
+  }
+
+  test("cache serializer definition lookup is safe when the entry is unavailable") {
+    AutoTuner.getCacheSerializerDefinition(Map.empty) shouldBe None
   }
 }

--- a/core/src/test/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManagerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/sql/rapids/tool/store/SQLPlanModelManagerSuite.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.rapids.tool.store
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Paths}
+
+import com.nvidia.spark.rapids.BaseNoSparkSuite
+import com.nvidia.spark.rapids.tool.EventLogPathProcessor
+import org.scalatest.matchers.should.Matchers._
+
+import org.apache.spark.scheduler.SparkListenerEvent
+import org.apache.spark.sql.TrampolineUtil
+import org.apache.spark.sql.execution.{SparkPlanInfo => UpstreamSparkPlanInfo}
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
+
+class SQLPlanModelManagerSuite extends BaseNoSparkSuite {
+
+  private class TestApp extends AppBase(None, None) {
+    override def processEvent(event: SparkListenerEvent): Boolean = false
+  }
+
+  private def plan(name: String, children: UpstreamSparkPlanInfo*): UpstreamSparkPlanInfo = {
+    new UpstreamSparkPlanInfo(name, name, children, Map.empty, Seq.empty)
+  }
+
+  private def withProfilingApp(f: ApplicationInfo => Unit): Unit = {
+    val events = Seq(
+      """{"Event":"SparkListenerLogStart","Spark Version":"3.5.0"}""",
+      """{"Event":"SparkListenerApplicationStart","App Name":"PlanTest",""" +
+        """"App ID":"local-plan-test","Timestamp":100000,"User":"test"}""",
+      """{"Event":"SparkListenerApplicationEnd","Timestamp":200000}""")
+    TrampolineUtil.withTempDir { tempDir =>
+      val eventLog = Paths.get(tempDir.getAbsolutePath, "eventlog")
+      Files.write(eventLog, events.mkString("\n").getBytes(StandardCharsets.UTF_8))
+      val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+      val eventLogInfo = EventLogPathProcessor
+        .getEventLogInfo(eventLog.toString, hadoopConf).head._1
+      f(new ApplicationInfo(hadoopConf, eventLogInfo))
+    }
+  }
+
+  test("SQL cache evidence includes every plan version and survives cleanup") {
+    val app = new TestApp
+
+    assert(!app.hasSqlCacheEvidence)
+
+    app.sqlManager.addNewExecution(1L, plan("Project"), "primary")
+    app.sqlManager.addAQE(1L,
+      plan("AdaptiveSparkPlan", plan("Filter", plan("InMemoryTableScan"))), "aqe-cache")
+    app.sqlManager.addAQE(1L, plan("Project"), "aqe-final")
+    app.sqlManager.addNewExecution(2L,
+      plan("Project", plan("InMemoryRelation"), plan("InMemoryRelation")), "second-sql")
+
+    app.hasSqlCacheEvidence shouldBe true
+
+    app.cleanupSQL(1L)
+    app.cleanupSQL(2L)
+
+    app.hasSqlCacheEvidence shouldBe true
+  }
+
+  test("SQL cache evidence uses normalized Spark names for platform-aware plans") {
+    withProfilingApp { app =>
+      app.gpuMode = true
+
+      app.sqlManager.addNewExecution(1L, plan("GpuInMemoryTableScan"), "gpu-plan")
+
+      app.sqlManager.getPlanInfoById(1L).get.platformName shouldBe "GpuInMemoryTableScan"
+      app.hasSqlCacheEvidence shouldBe true
+    }
+  }
+
+  Seq(
+    "InMemoryRelation",
+    "InMemoryTableScan",
+    "TableCacheQueryStage",
+    "GpuInMemoryTableScan",
+    "Scan In-memory table hot_orders").foreach { cacheNodeName =>
+    test(s"SQL cache evidence recognizes '$cacheNodeName'") {
+      val app = new TestApp
+
+      app.sqlManager.addNewExecution(1L,
+        plan("Project", plan(cacheNodeName)), "cache-plan")
+
+      app.hasSqlCacheEvidence shouldBe true
+    }
+  }
+
+  test("non-cache scan names do not produce SQL cache evidence") {
+    val app = new TestApp
+
+    app.sqlManager.addNewExecution(1L,
+      plan("Project", plan("Scan parquet orders")), "non-cache-plan")
+
+    app.hasSqlCacheEvidence shouldBe false
+  }
+}


### PR DESCRIPTION
Fixes #2116

## Summary

This PR adds a shared AutoTuner heuristic that recommends `spark.sql.cache.serializer=com.nvidia.spark.ParquetCachedBatchSerializer` when an application uses Spark SQL caching.

## Approach

- Detect cache evidence in every observed SQL plan version, including AQE updates that are later replaced or cleaned up.
- Recognize `InMemoryRelation`, `InMemoryTableScan`, `TableCacheQueryStage`, `GpuInMemoryTableScan`, and Spark's named-cache scan form (`Scan In-memory table <name>`).
- Inspect structured stage RDD scopes when Spark omits cache operators from SQL plan events.
- Keep only a Boolean cache-evidence signal and stop traversing plans/scopes once evidence is found.
- Expose the same signal to Qualification and Profiling AutoTuner providers.
- Read the recommended serializer and Spark default from the existing tuning YAML files.

## Configuration behavior

- Missing values and Spark's default serializer are replaced with the configured RAPIDS serializer.
- An already-correct serializer is unchanged.
- A custom serializer is preserved with a compatibility advisory.
- Preserved or enforced target-cluster values remain unchanged and retain the advisory; a preserve directive without a source value does not suppress the recommendation.
- Excluded properties receive no recommendation.
- If `spark.rapids.sql.exec.InMemoryTableScanExec` is explicitly disabled, AutoTuner suppresses the serializer recommendation and reports that GPU cache scans remain disabled.
- Spark 3.5.0 and 3.5.1 receive an advisory that GPU `InMemoryTableScan` remains disabled under AQE.

## Testing

- 104 focused tests passed across the Profiling AutoTuner, Qualification AutoTuner, provider integration, and SQL plan model suites.
- A Spark-generated named-cache event log asserts the actual `Scan In-memory table hot_orders` node and verifies both Qualification and Profiling recommendations.
- The Spark-generated integration suite passed with Spark 3.4.4, 3.5.1, and 3.5.7 Maven build profiles.
- `mvn clean package -DskipTests` completed successfully for the Scala 2.12 JAR.

## Known limitation

The core module does not currently provide a Spark 4 Maven build profile. Spark 4 plan-shape coverage should use a Spark-4-produced cache event log in the asserting qualification and profiling golden-set jobs.
