### PR TITLE
Fix cache-derived maxPartitionBytes recommendations

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -48,6 +48,7 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
     }
   }
   override def getSparkVersion: Option[String] = None
+  override def getMaxFileScanInput: Option[Double] = None
   override def getMaxInput: Double = 0.0
   override def getMeanInput: Double = 0.0
   override def getMeanShuffleRead: Double = 0.0

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/AppSummaryInfoBaseProvider.scala
@@ -49,7 +49,6 @@ class AppSummaryInfoBaseProvider extends AppInfoPropertyGetter
   }
   override def getSparkVersion: Option[String] = None
   override def getMaxFileScanInput: Option[Double] = None
-  override def getMaxInput: Double = 0.0
   override def getMeanInput: Double = 0.0
   override def getMeanShuffleRead: Double = 0.0
   override def getJvmGCFractions: Seq[Double] = Seq()

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -82,6 +82,7 @@ trait AppInfoJobStageAggMetricsVisitor {
 }
 
 trait AppInfoSQLTaskInputSizes {
+  def getMaxFileScanInput: Option[Double]
   def getMaxInput: Double
   def getMeanInput: Double
   def getMeanShuffleRead: Double

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -84,7 +84,6 @@ trait AppInfoJobStageAggMetricsVisitor {
 
 trait AppInfoSQLTaskInputSizes {
   def getMaxFileScanInput: Option[Double]
-  def getMaxInput: Double
   def getMeanInput: Double
   def getMeanShuffleRead: Double
 }
@@ -188,14 +187,6 @@ class SingleAppSummaryInfoProvider(
 
   override def getShuffleSkewStages: Set[Long] = {
     app.skewInfo.map { row => row.stageId }.toSet
-  }
-
-  override def getMaxInput: Double = {
-    if (app.sqlTaskAggMetrics.nonEmpty) {
-      app.sqlTaskAggMetrics.map(_.inputBytesReadMax).max.toDouble
-    } else {
-      0.0
-    }
   }
 
   protected[tool] def planGraphForSqlVersion(

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationSummaryInfo.scala
@@ -18,10 +18,11 @@ package com.nvidia.spark.rapids.tool.profiling
 
 import com.nvidia.spark.rapids.SparkRapidsBuildInfoEvent
 import com.nvidia.spark.rapids.tool.AppSummaryInfoBaseProvider
-import com.nvidia.spark.rapids.tool.tuning.{SparkMaster, Yarn}
+import com.nvidia.spark.rapids.tool.tuning.{FileScanInputMetrics, SparkMaster, Yarn}
 import com.nvidia.spark.rapids.tool.views.{IoMetrics, WriteOpProfileResult}
 
 import org.apache.spark.ExecutorLostFailure
+import org.apache.spark.sql.rapids.tool.plangraph.ToolsPlanGraph
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 
 case class ApplicationSummaryInfo(
@@ -195,6 +196,16 @@ class SingleAppSummaryInfoProvider(
     } else {
       0.0
     }
+  }
+
+  protected[tool] def planGraphForSqlVersion(
+      sqlId: Long, version: Int): Option[ToolsPlanGraph] = {
+    FileScanInputMetrics.latestPlanGraph(appInfo, sqlId, version)
+  }
+
+  override lazy val getMaxFileScanInput: Option[Double] = {
+    FileScanInputMetrics.maxInputBytes(
+      app.dsInfo, app.stageAggMetrics, planGraphForSqlVersion)
   }
 
   override def getRapidsJars: Seq[String] = {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -1590,10 +1590,8 @@ abstract class AutoTuner(
   }
 
   /**
-   * Calculate max partition bytes using the max task input size and existing setting
-   * for maxPartitionBytes. Note that this won't apply the same on iceberg.
-   * The max bytes here does not distinguish between GPU and CPU reads so we could
-   * improve that in the future.
+   * Calculate max partition bytes using a max input size from a trustworthy file scan stage and
+   * the existing setting for maxPartitionBytes. Note that this won't apply the same on iceberg.
    * Eg,
    * TASK_INPUT_SIZE_THRESHOLD = {min: 128m, max: 256m}
    * (1) Input:  currentMaxPartitionBytes = 512m
@@ -1604,29 +1602,29 @@ abstract class AutoTuner(
    *     Output: recommendedMaxPartitionBytes = 2g / (512m/128m) = 512m
    */
   protected def calculateMaxPartitionBytesInMB(currentMaxPartitionBytes: String): Option[Long] = {
-    // AutoTuner only supports a single app right now, so we get whatever value is here
-    val actualTaskInputSizeMB = appInfoProvider.getMaxInput / 1024 / 1024
-    val currentMaxPartitionBytesMB = StringUtils.convertToMB(
-      currentMaxPartitionBytes, Some(ByteUnit.BYTE))
-    // Get the min and max thresholds for the task input size
-    val taskInputSizeThreshold = configProvider.getEntry("TASK_INPUT_SIZE_THRESHOLD")
-    val minTaskInputSizeThresholdMB = taskInputSizeThreshold.getMinAsMemory(ByteUnit.MiB)
-    val maxTaskInputSizeThresholdMB = taskInputSizeThreshold.getMaxAsMemory(ByteUnit.MiB)
-    // Get the upper bound for the max partition bytes
-    val maxAllowedPartitionBytesMB =
-      configProvider.getEntry("MAX_PARTITION_BYTES").getMaxAsMemory(ByteUnit.MiB)
+    appInfoProvider.getMaxFileScanInput.flatMap { maxFileScanInput =>
+      val actualTaskInputSizeMB = maxFileScanInput / 1024 / 1024
+      val currentMaxPartitionBytesMB = StringUtils.convertToMB(
+        currentMaxPartitionBytes, Some(ByteUnit.BYTE))
+      // Get the min and max thresholds for the task input size
+      val taskInputSizeThreshold = configProvider.getEntry("TASK_INPUT_SIZE_THRESHOLD")
+      val minTaskInputSizeThresholdMB = taskInputSizeThreshold.getMinAsMemory(ByteUnit.MiB)
+      val maxTaskInputSizeThresholdMB = taskInputSizeThreshold.getMaxAsMemory(ByteUnit.MiB)
+      // Get the upper bound for the max partition bytes
+      val maxAllowedPartitionBytesMB =
+        configProvider.getEntry("MAX_PARTITION_BYTES").getMaxAsMemory(ByteUnit.MiB)
 
-    if (actualTaskInputSizeMB == 0.0) {
-      Some(currentMaxPartitionBytesMB)
-    } else {
-      if (actualTaskInputSizeMB > 0 && actualTaskInputSizeMB < minTaskInputSizeThresholdMB) {
+      if (actualTaskInputSizeMB == 0.0) {
+        Some(currentMaxPartitionBytesMB)
+      } else if (actualTaskInputSizeMB > 0 &&
+          actualTaskInputSizeMB < minTaskInputSizeThresholdMB) {
         // If task input too small (< min threshold): increase partition size to get bigger tasks
         val recommendedMaxPartitionBytesMB = Math.min(
           currentMaxPartitionBytesMB * (minTaskInputSizeThresholdMB / actualTaskInputSizeMB),
           maxAllowedPartitionBytesMB)
         Some(recommendedMaxPartitionBytesMB.toLong)
       } else if (actualTaskInputSizeMB > maxTaskInputSizeThresholdMB) {
-        //  If task input too large (> max threshold): decrease partition size to get smaller tasks
+        // If task input too large (> max threshold): decrease partition size to get smaller tasks
         val recommendedMaxPartitionBytesMB = Math.min(
           currentMaxPartitionBytesMB / (actualTaskInputSizeMB / maxTaskInputSizeThresholdMB),
           maxAllowedPartitionBytesMB)
@@ -2227,7 +2225,8 @@ class ProfilingAutoTuner(
     // First, calculate the recommendation based on input sizes
     val calculatedValueFromInputSize = super.calculateMaxPartitionBytesInMB(maxPartitionBytes)
     getPropertyValue("spark.sql.files.maxPartitionBytes") match {
-      case Some(currentValue) if appInfoProvider.scanStagesWithGpuOom.nonEmpty =>
+      case Some(currentValue) if appInfoProvider.getMaxFileScanInput.nonEmpty &&
+          appInfoProvider.scanStagesWithGpuOom.nonEmpty =>
         // GPU OOM detected. We may want to reduce max partition size.
         val halvedValue = StringUtils.convertToMB(currentValue, Some(ByteUnit.BYTE)) / 2
         // Choose the minimum between the calculated value and half of the current value.

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetrics.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetrics.scala
@@ -18,7 +18,8 @@ package com.nvidia.spark.rapids.tool.tuning
 
 import scala.util.Try
 
-import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, StageAggTaskMetricsProfileResult}
+import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult,
+  StageAggTaskMetricsProfileResult}
 
 import org.apache.spark.sql.rapids.tool.AppBase
 import org.apache.spark.sql.rapids.tool.plangraph.ToolsPlanGraph

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetrics.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetrics.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.tuning
+
+import scala.util.Try
+
+import com.nvidia.spark.rapids.tool.profiling.{DataSourceProfileResult, StageAggTaskMetricsProfileResult}
+
+import org.apache.spark.sql.rapids.tool.AppBase
+import org.apache.spark.sql.rapids.tool.plangraph.ToolsPlanGraph
+
+private[tool] object FileScanInputMetrics {
+  private val cachePlanNodes = Seq("InMemoryTableScan", "InMemoryRelation")
+
+  def latestPlanGraph(
+      appInfo: AppBase,
+      sqlId: Long,
+      version: Int): Option[ToolsPlanGraph] = {
+    appInfo.sqlManager.applyToPlanModel(sqlId) { planModel =>
+      if (planModel.plan.version == version) {
+        Try(planModel.getToolsPlanGraph).toOption
+      } else {
+        None
+      }
+    }.flatten
+  }
+
+  def maxInputBytes(
+      dataSources: Seq[DataSourceProfileResult],
+      stageMetrics: Seq[StageAggTaskMetricsProfileResult],
+      planGraphForSqlVersion: (Long, Int) => Option[ToolsPlanGraph]): Option[Double] = {
+    val candidateStages = dataSources.iterator
+      .filter(_.fromFinalPlan)
+      .flatMap { dataSource =>
+        planGraphForSqlVersion(dataSource.sqlID, dataSource.version).iterator.flatMap { graph =>
+          graph.getNodeStageRawAssignment(dataSource.nodeId).iterator.filter { stageId =>
+            val stageNodeIds = graph.getStageNodesByRawAssignment(stageId)
+            val stageNodes = graph.allNodes.filter(node => stageNodeIds.contains(node.id))
+            stageNodes.nonEmpty && !stageNodes.exists { node =>
+              Seq(node.name, node.desc).exists { text =>
+                Option(text).exists(nonNullText => cachePlanNodes.exists(nonNullText.contains))
+              }
+            }
+          }.map(_.toLong)
+        }
+      }.toSet
+
+    stageMetrics.iterator
+      .filter(metric => candidateStages.contains(metric.id))
+      .map(_.inputBytesReadMax)
+      .filter(_ > 0L)
+      .reduceOption((left: Long, right: Long) => math.max(left, right))
+      .map(_.toDouble)
+  }
+}

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
@@ -98,14 +98,6 @@ class QualAppSummaryInfoProvider(
     rawAggMetrics.taskShuffleSkew.map { row => row.stageId }.toSet
   }
 
-  override def getMaxInput: Double = {
-    if (rawAggMetrics.sqlAggs.nonEmpty) {
-      rawAggMetrics.sqlAggs.map(_.inputBytesReadMax).max.toDouble
-    } else {
-      0.0
-    }
-  }
-
   protected[tool] def planGraphForSqlVersion(
       sqlId: Long, version: Int): Option[ToolsPlanGraph] = {
     FileScanInputMetrics.latestPlanGraph(appInfo, sqlId, version)

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/QualAppSummaryInfoProvider.scala
@@ -21,6 +21,7 @@ import com.nvidia.spark.rapids.tool.analysis.AggRawMetricsResult
 import com.nvidia.spark.rapids.tool.profiling.DataSourceProfileResult
 
 import org.apache.spark.internal.Logging
+import org.apache.spark.sql.rapids.tool.plangraph.ToolsPlanGraph
 import org.apache.spark.sql.rapids.tool.qualification.{QualificationAppInfo, QualificationSummaryInfo}
 
 /**
@@ -103,6 +104,16 @@ class QualAppSummaryInfoProvider(
     } else {
       0.0
     }
+  }
+
+  protected[tool] def planGraphForSqlVersion(
+      sqlId: Long, version: Int): Option[ToolsPlanGraph] = {
+    FileScanInputMetrics.latestPlanGraph(appInfo, sqlId, version)
+  }
+
+  override lazy val getMaxFileScanInput: Option[Double] = {
+    FileScanInputMetrics.maxInputBytes(
+      dsInfo, rawAggMetrics.stageAggs, planGraphForSqlVersion)
   }
 
   // Rapids Jar will be empty since CPU event logs are used here

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ClusterRecommendationSuite.scala
@@ -346,7 +346,6 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
             |--conf spark.rapids.sql.multiThreadedRead.numThreads=40
             |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
             |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=400
-            |--conf spark.sql.files.maxPartitionBytes=1851m
             |--conf spark.sql.shuffle.partitions=400
             |--conf spark.task.resource.gpu.amount=0.001
             |
@@ -469,7 +468,6 @@ class ClusterRecommendationSuite extends ProfilingAutoTunerSuiteBase
             |--conf spark.rapids.sql.multiThreadedRead.numThreads=40
             |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
             |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=400
-            |--conf spark.sql.files.maxPartitionBytes=1851m
             |--conf spark.sql.shuffle.partitions=400
             |--conf spark.task.resource.gpu.amount=0.001
             |

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -57,7 +57,6 @@ class AppInfoProviderMockTest(val maxInput: Double,
   override def isAppInfoAvailable = true
   override def getMaxFileScanInput: Option[Double] =
     maxFileScanInputOverride.getOrElse(Some(maxInput))
-  override def getMaxInput: Double = maxInput
   override def getMeanInput: Double = meanInput
   override def getMeanShuffleRead: Double = meanShuffleRead
   override def getSpilledMetrics: Seq[Long] = spilledMetrics

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -51,9 +51,12 @@ class AppInfoProviderMockTest(val maxInput: Double,
     val shuffleSkewStages: Set[Long],
     val scanStagesWithGpuOomSet: Set[Long],
     val gpuShuffleStagesWithContainerOomSet: Set[Long],
-    val maxColumnarExchangeDataSizeBytes: Option[Long] = None)
+    val maxColumnarExchangeDataSizeBytes: Option[Long] = None,
+    val maxFileScanInputOverride: Option[Option[Double]] = None)
     extends BaseProfilingAppSummaryInfoProvider {
   override def isAppInfoAvailable = true
+  override def getMaxFileScanInput: Option[Double] =
+    maxFileScanInputOverride.getOrElse(Some(maxInput))
   override def getMaxInput: Double = maxInput
   override def getMeanInput: Double = meanInput
   override def getMeanShuffleRead: Double = meanShuffleRead
@@ -137,11 +140,13 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
       shuffleSkewStages: Set[Long] = Set(),
       scanStagesWithGpuOom: Set[Long] = Set(),
       gpuShuffleStagesWithContainerOom: Set[Long] = Set(),
-      maxColumnarExchangeDataSizeBytes: Option[Long] = None): AppInfoProviderMockTest = {
+      maxColumnarExchangeDataSizeBytes: Option[Long] = None,
+      maxFileScanInputOverride: Option[Option[Double]] = None): AppInfoProviderMockTest = {
     new AppInfoProviderMockTest(maxInput, spilledMetrics, jvmGCFractions, propsFromLog,
       sparkVersion, rapidsJars, distinctLocationPct, redundantReadSize, meanInput, meanShuffleRead,
       shuffleStagesWithPosSpilling, shuffleSkewStages, scanStagesWithGpuOom,
-      gpuShuffleStagesWithContainerOom, maxColumnarExchangeDataSizeBytes)
+      gpuShuffleStagesWithContainerOom, maxColumnarExchangeDataSizeBytes,
+      maxFileScanInputOverride)
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
@@ -18,9 +18,90 @@ package com.nvidia.spark.rapids.tool.tuning
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.AppSummaryInfoBaseProvider
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogPathProcessor, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.profiling.{CollectInformation, DataSourceProfileResult, ProfileArgs, StageAggTaskMetricsProfileResult}
+import com.nvidia.spark.rapids.tool.views.RawMetricProfilerView
+
+import org.apache.spark.sql.rapids.tool.AccumToStageRetriever
+import org.apache.spark.sql.rapids.tool.plangraph.{SQLPlanMetric, SparkPlanGraph, SparkPlanGraphNode, ToolsPlanGraph}
+import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
+import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
 class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
+  private val oneMiB = 1024L * 1024L
+
+  private case class GraphNodeSpec(
+      id: Long,
+      name: String,
+      desc: String,
+      stageId: Int)
+
+  private def buildGraph(specs: Seq[GraphNodeSpec]): ToolsPlanGraph = {
+    val accumIdToStage = specs.map(spec => (1000L + spec.id) -> spec.stageId).toMap
+    val nodes = specs.map { spec =>
+      new SparkPlanGraphNode(
+        spec.id,
+        spec.name,
+        spec.desc,
+        Seq(SQLPlanMetric("number of output rows", 1000L + spec.id, "sum")))
+    }
+    val retriever = new AccumToStageRetriever {
+      override def getStageIDsFromAccumIds(accumIds: Seq[Long]): Set[Int] = {
+        accumIds.flatMap(accumIdToStage.get).toSet
+      }
+    }
+    new ToolsPlanGraph(SparkPlanGraph(nodes, Seq.empty), retriever)
+  }
+
+  private def dataSource(
+      sqlId: Long,
+      version: Int,
+      nodeId: Long,
+      fromFinalPlan: Boolean = true): DataSourceProfileResult = {
+    DataSourceProfileResult(
+      sqlId, version, nodeId, "Parquet", 0L, 0L, 0L, 0L,
+      "file:/input", "", "struct<id:long>", "", "", fromFinalPlan)
+  }
+
+  private def stageMetric(
+      stageId: Long,
+      maxInputBytes: Long,
+      numTasks: Int = 1): StageAggTaskMetricsProfileResult = {
+    StageAggTaskMetricsProfileResult(
+      id = stageId,
+      numTasks = numTasks,
+      duration = None,
+      diskBytesSpilledSum = 0L,
+      durationSum = 0L,
+      durationMax = 0L,
+      durationMin = 0L,
+      durationAvg = 0.0,
+      executorCPUTimeSum = 0L,
+      executorDeserializeCpuTimeSum = 0L,
+      executorDeserializeTimeSum = 0L,
+      executorRunTimeSum = 0L,
+      inputBytesReadSum = maxInputBytes,
+      inputBytesReadMax = maxInputBytes,
+      inputRecordsReadSum = 0L,
+      jvmGCTimeSum = 0L,
+      memoryBytesSpilledSum = 0L,
+      outputBytesWrittenSum = 0L,
+      outputRecordsWrittenSum = 0L,
+      peakExecutionMemoryMax = 0L,
+      resultSerializationTimeSum = 0L,
+      resultSizeMax = 0L,
+      srFetchWaitTimeSum = 0L,
+      srLocalBlocksFetchedSum = 0L,
+      srcLocalBytesReadSum = 0L,
+      srRemoteBlocksFetchSum = 0L,
+      srRemoteBytesReadSum = 0L,
+      srRemoteBytesReadToDiskSum = 0L,
+      srTotalBytesReadSum = 0L,
+      swBytesWrittenSum = 0L,
+      swRecordsWrittenSum = 0L,
+      swWriteTimeSum = 0L)
+  }
+
   test("base provider reports no reliable file scan input") {
     assert(new AppSummaryInfoBaseProvider().getMaxFileScanInput.isEmpty)
   }
@@ -34,5 +115,126 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
       sparkVersion = Some(testSparkVersion),
       maxFileScanInputOverride = Some(None))
     assert(provider.getMaxFileScanInput.isEmpty)
+  }
+
+  test("uses the largest genuine final-plan file scan stage input") {
+    val graph = buildGraph(Seq(
+      GraphNodeSpec(10L, "Scan parquet", "file scan", 10),
+      GraphNodeSpec(11L, "BatchScan parquet", "data source scan", 11)))
+    val dataSources = Seq(dataSource(1L, 1, 10L), dataSource(1L, 1, 11L))
+    val stageMetrics = Seq(stageMetric(10L, 300L * oneMiB), stageMetric(11L, 192L * oneMiB))
+
+    val result = FileScanInputMetrics.maxInputBytes(
+      dataSources, stageMetrics, (_, version) => if (version == 1) Some(graph) else None)
+
+    assert(result.contains(300.0 * oneMiB))
+  }
+
+  test("excludes stages containing InMemoryTableScan or InMemoryRelation") {
+    val graph = buildGraph(Seq(
+      GraphNodeSpec(10L, "Scan parquet", "file scan", 20),
+      GraphNodeSpec(12L, "InMemoryTableScan", "InMemoryRelation cached", 20),
+      GraphNodeSpec(11L, "Scan parquet", "genuine file scan", 10)))
+    val dataSources = Seq(dataSource(1L, 1, 10L), dataSource(1L, 1, 11L))
+    val stageMetrics = Seq(stageMetric(20L, 3140L * oneMiB), stageMetric(10L, 300L * oneMiB))
+
+    val result = FileScanInputMetrics.maxInputBytes(
+      dataSources, stageMetrics, (_, _) => Some(graph))
+
+    assert(result.contains(300.0 * oneMiB))
+  }
+
+  test("returns None without a trustworthy file scan") {
+    val stageMetrics = Seq(stageMetric(20L, 3140L * oneMiB))
+
+    assert(FileScanInputMetrics.maxInputBytes(
+      Seq.empty, stageMetrics, (_, _) => None).isEmpty)
+  }
+
+  test("AQE version mismatch cannot reuse a latest-plan node ID") {
+    val graph = buildGraph(Seq(GraphNodeSpec(10L, "Scan parquet", "file scan", 20)))
+    val staleDataSource = dataSource(1L, 0, 10L)
+    val stageMetrics = Seq(stageMetric(20L, 300L * oneMiB))
+
+    assert(FileScanInputMetrics.maxInputBytes(
+      Seq(staleDataSource), stageMetrics,
+      (_, version) => if (version == 1) Some(graph) else None).isEmpty)
+  }
+
+  test("nullable and empty plan descriptions are safe") {
+    val nullDescGraph = buildGraph(Seq(GraphNodeSpec(10L, "Scan parquet", null, 20)))
+    val emptyDescGraph = buildGraph(Seq(GraphNodeSpec(10L, "Scan parquet", "", 20)))
+    val cacheGraph = buildGraph(Seq(GraphNodeSpec(10L, "InMemoryTableScan", null, 20)))
+    val dataSources = Seq(dataSource(1L, 1, 10L))
+    val stageMetrics = Seq(stageMetric(20L, 300L * oneMiB))
+
+    assert(FileScanInputMetrics.maxInputBytes(
+      dataSources, stageMetrics, (_, _) => Some(nullDescGraph)).nonEmpty)
+    assert(FileScanInputMetrics.maxInputBytes(
+      dataSources, stageMetrics, (_, _) => Some(emptyDescGraph)).nonEmpty)
+    assert(FileScanInputMetrics.maxInputBytes(
+      dataSources, stageMetrics, (_, _) => Some(cacheGraph)).isEmpty)
+  }
+
+  test("rejects non-final, missing, unmapped, and zero-only scan inputs") {
+    val mappedGraph = buildGraph(Seq(GraphNodeSpec(10L, "Scan parquet", "file scan", 20)))
+    val unmappedGraph = buildGraph(Seq(GraphNodeSpec(11L, "Scan parquet", "file scan", 20)))
+    val positiveStage = Seq(stageMetric(20L, 300L * oneMiB))
+
+    assert(FileScanInputMetrics.maxInputBytes(
+      Seq(dataSource(1L, 1, 10L, fromFinalPlan = false)), positiveStage,
+      (_, _) => Some(mappedGraph)).isEmpty)
+    assert(FileScanInputMetrics.maxInputBytes(
+      Seq(dataSource(1L, 1, 10L)), positiveStage, (_, _) => None).isEmpty)
+    assert(FileScanInputMetrics.maxInputBytes(
+      Seq(dataSource(1L, 1, 10L)), positiveStage,
+      (_, _) => Some(unmappedGraph)).isEmpty)
+    assert(FileScanInputMetrics.maxInputBytes(
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 0L)),
+      (_, _) => Some(mappedGraph)).isEmpty)
+  }
+
+  test("real AQE final Parquet data source binds to the latest plan version") {
+    val hadoopConf = RapidsToolsConfUtil.newHadoopConf()
+    val eventLogPath = ToolTestUtils.getTestResourcePath(
+      "spark-events-qualification/nds_q72_dataproc_2_2.zstd")
+    val appArgs = new ProfileArgs(Array(eventLogPath))
+    val eventLogInfo = EventLogPathProcessor
+      .getEventLogInfo(appArgs.eventlog().head, hadoopConf).head._1
+    val app = new ApplicationInfo(hadoopConf, eventLogInfo)
+    val collect = new CollectInformation(Seq(app))
+    val dataSources = collect.getDataSourceInfo.filter { ds =>
+      ds.fromFinalPlan && ds.format.toLowerCase.contains("parquet")
+    }
+    val stageMetrics = RawMetricProfilerView.getAggMetrics(Seq(app)).stageAggs
+
+    assert(dataSources.nonEmpty)
+    dataSources.foreach { ds =>
+      val latestVersion = app.sqlManager.getPlanById(ds.sqlID).map(_.plan.version)
+      assert(latestVersion.contains(ds.version))
+      assert(FileScanInputMetrics.latestPlanGraph(app, ds.sqlID, ds.version - 1).isEmpty)
+    }
+    val result = FileScanInputMetrics.maxInputBytes(
+      dataSources, stageMetrics,
+      (sqlId, version) => FileScanInputMetrics.latestPlanGraph(app, sqlId, version))
+    val mappings = dataSources.map { ds =>
+      val stages = FileScanInputMetrics.latestPlanGraph(app, ds.sqlID, ds.version)
+        .map { graph =>
+          (graph.getNodeStageRawAssignment(ds.nodeId),
+            graph.getNodeStageLogicalAssignment(ds.nodeId))
+        }.getOrElse((Set.empty, Set.empty))
+      (ds.sqlID, ds.version, ds.nodeId, ds.format, stages)
+    }
+    val graphScanNodes = FileScanInputMetrics.latestPlanGraph(
+      app, dataSources.head.sqlID, dataSources.head.version).toSeq.flatMap { graph =>
+      graph.allNodes.filter(node => Option(node.name).exists(_.toLowerCase.contains("scan")))
+        .map { node =>
+          (node.id, node.name, graph.getNodeStageRawAssignment(node.id),
+            graph.getNodeStageLogicalAssignment(node.id), node.metrics.map(_.accumulatorId))
+        }
+    }
+    assert(result.nonEmpty, s"dataSources=$mappings stageInputs=" +
+      stageMetrics.map(metric => metric.id -> metric.inputBytesReadMax) +
+      s" graphScanNodes=$graphScanNodes")
   }
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
@@ -19,7 +19,8 @@ package com.nvidia.spark.rapids.tool.tuning
 import scala.collection.mutable
 
 import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogPathProcessor, ToolTestUtils}
-import com.nvidia.spark.rapids.tool.profiling.{CollectInformation, DataSourceProfileResult, ProfileArgs, StageAggTaskMetricsProfileResult}
+import com.nvidia.spark.rapids.tool.analysis.AggRawMetricsResult
+import com.nvidia.spark.rapids.tool.profiling.{ApplicationSummaryInfo, CollectInformation, DataSourceProfileResult, ProfileArgs, SingleAppSummaryInfoProvider, StageAggTaskMetricsProfileResult}
 import com.nvidia.spark.rapids.tool.views.RawMetricProfilerView
 
 import org.apache.spark.sql.rapids.tool.AccumToStageRetriever
@@ -102,6 +103,70 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
       swWriteTimeSum = 0L)
   }
 
+  private def rawMetrics(stages: Seq[StageAggTaskMetricsProfileResult]): AggRawMetricsResult = {
+    AggRawMetricsResult(
+      jobAggs = Seq.empty,
+      stageAggs = stages,
+      taskShuffleSkew = Seq.empty,
+      sqlAggs = Seq.empty,
+      ioAggs = Seq.empty,
+      sqlDurAggs = Seq.empty,
+      stageDiagnostics = Seq.empty)
+  }
+
+  private def appSummary(
+      dataSources: Seq[DataSourceProfileResult],
+      stages: Seq[StageAggTaskMetricsProfileResult]): ApplicationSummaryInfo = {
+    ApplicationSummaryInfo(
+      appInfo = Seq.empty,
+      dsInfo = dataSources,
+      execInfo = Seq.empty,
+      jobInfo = Seq.empty,
+      rapidsProps = Seq.empty,
+      rapidsJar = Seq.empty,
+      sqlMetrics = Seq.empty,
+      stageMetrics = Seq.empty,
+      jobAggMetrics = Seq.empty,
+      stageAggMetrics = stages,
+      sqlTaskAggMetrics = Seq.empty,
+      durAndCpuMet = Seq.empty,
+      skewInfo = Seq.empty,
+      failedTasks = Seq.empty,
+      failedStages = Seq.empty,
+      failedJobs = Seq.empty,
+      removedBMs = Seq.empty,
+      removedExecutors = Seq.empty,
+      unsupportedOps = Seq.empty,
+      sparkProps = Seq.empty,
+      sqlStageInfo = Seq.empty,
+      wholeStage = Seq.empty,
+      appLogPath = Seq.empty,
+      ioMetrics = Seq.empty,
+      sysProps = Seq.empty,
+      sqlCleanedAlignedIds = Seq.empty,
+      sparkRapidsBuildInfo = Seq.empty,
+      writeOpsInfo = Seq.empty,
+      sqlPlanInfo = Seq.empty)
+  }
+
+  private class TestQualProvider(
+      dataSources: Seq[DataSourceProfileResult],
+      stages: Seq[StageAggTaskMetricsProfileResult],
+      graph: Option[ToolsPlanGraph])
+    extends QualAppSummaryInfoProvider(null, None, rawMetrics(stages), dataSources) {
+    override protected[tool] def planGraphForSqlVersion(
+        sqlId: Long, version: Int): Option[ToolsPlanGraph] = graph
+  }
+
+  private class TestProfilingProvider(
+      dataSources: Seq[DataSourceProfileResult],
+      stages: Seq[StageAggTaskMetricsProfileResult],
+      graph: Option[ToolsPlanGraph])
+    extends SingleAppSummaryInfoProvider(null, appSummary(dataSources, stages)) {
+    override protected[tool] def planGraphForSqlVersion(
+        sqlId: Long, version: Int): Option[ToolsPlanGraph] = graph
+  }
+
   test("base provider reports no reliable file scan input") {
     assert(new AppSummaryInfoBaseProvider().getMaxFileScanInput.isEmpty)
   }
@@ -115,6 +180,35 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
       sparkVersion = Some(testSparkVersion),
       maxFileScanInputOverride = Some(None))
     assert(provider.getMaxFileScanInput.isEmpty)
+  }
+
+  test("qualification provider rejects the CI34 257 MiB cache-only input") {
+    val graph = buildGraph(Seq(
+      GraphNodeSpec(10L, "InMemoryTableScan", "InMemoryRelation cached", 20)))
+    val provider = new TestQualProvider(
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 257L * oneMiB, 500)), Some(graph))
+
+    assert(provider.getMaxFileScanInput.isEmpty)
+  }
+
+  test("profiling provider rejects the CI34 3140 MiB cache-only input") {
+    val graph = buildGraph(Seq(
+      GraphNodeSpec(10L, "InMemoryTableScan", "InMemoryRelation cached", 20)))
+    val provider = new TestProfilingProvider(
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 3140L * oneMiB, 96)), Some(graph))
+
+    assert(provider.getMaxFileScanInput.isEmpty)
+  }
+
+  test("both concrete providers expose genuine file scan input") {
+    val graph = buildGraph(Seq(GraphNodeSpec(10L, "Scan parquet", "file scan", 20)))
+    val dataSources = Seq(dataSource(1L, 1, 10L))
+    val stages = Seq(stageMetric(20L, 512L * oneMiB))
+
+    assert(new TestQualProvider(dataSources, stages, Some(graph))
+      .getMaxFileScanInput.contains(512.0 * oneMiB))
+    assert(new TestProfilingProvider(dataSources, stages, Some(graph))
+      .getMaxFileScanInput.contains(512.0 * oneMiB))
   }
 
   test("uses the largest genuine final-plan file scan stage input") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.nvidia.spark.rapids.tool.tuning
+
+import scala.collection.mutable
+
+import com.nvidia.spark.rapids.tool.AppSummaryInfoBaseProvider
+
+class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
+  test("base provider reports no reliable file scan input") {
+    assert(new AppSummaryInfoBaseProvider().getMaxFileScanInput.isEmpty)
+  }
+
+  test("AutoTuner test provider can represent an absent reliable input") {
+    val provider = getMockInfoProvider(
+      maxInput = 3292825256.0,
+      spilledMetrics = Seq.empty,
+      jvmGCFractions = Seq.empty,
+      propsFromLog = mutable.Map.empty[String, String],
+      sparkVersion = Some(testSparkVersion),
+      maxFileScanInputOverride = Some(None))
+    assert(provider.getMaxFileScanInput.isEmpty)
+  }
+}

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
@@ -18,13 +18,17 @@ package com.nvidia.spark.rapids.tool.tuning
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogPathProcessor, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.{AppSummaryInfoBaseProvider, EventLogPathProcessor,
+  PlatformFactory, PlatformNames, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.analysis.AggRawMetricsResult
-import com.nvidia.spark.rapids.tool.profiling.{ApplicationSummaryInfo, CollectInformation, DataSourceProfileResult, ProfileArgs, SingleAppSummaryInfoProvider, StageAggTaskMetricsProfileResult}
+import com.nvidia.spark.rapids.tool.profiling.{ApplicationSummaryInfo, CollectInformation,
+  DataSourceProfileResult, ProfileArgs, SingleAppSummaryInfoProvider,
+  StageAggTaskMetricsProfileResult}
 import com.nvidia.spark.rapids.tool.views.RawMetricProfilerView
 
 import org.apache.spark.sql.rapids.tool.AccumToStageRetriever
-import org.apache.spark.sql.rapids.tool.plangraph.{SQLPlanMetric, SparkPlanGraph, SparkPlanGraphNode, ToolsPlanGraph}
+import org.apache.spark.sql.rapids.tool.plangraph.{SQLPlanMetric, SparkPlanGraph,
+  SparkPlanGraphNode, ToolsPlanGraph}
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 
@@ -152,19 +156,51 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
   private class TestQualProvider(
       dataSources: Seq[DataSourceProfileResult],
       stages: Seq[StageAggTaskMetricsProfileResult],
-      graph: Option[ToolsPlanGraph])
+      graph: Option[ToolsPlanGraph],
+      properties: Map[String, String] = Map.empty)
     extends QualAppSummaryInfoProvider(null, None, rawMetrics(stages), dataSources) {
     override protected[tool] def planGraphForSqlVersion(
         sqlId: Long, version: Int): Option[ToolsPlanGraph] = graph
+    override def getAllProperties: Map[String, String] = properties
+    override def getSparkProperty(propKey: String): Option[String] = properties.get(propKey)
+    override def getRapidsProperty(propKey: String): Option[String] = properties.get(propKey)
+    override def getSystemProperty(propKey: String): Option[String] = None
+    override def getSparkVersion: Option[String] = Some(testSparkVersion)
+    override def getClassPathEntries: Map[String, String] = Map.empty
   }
 
   private class TestProfilingProvider(
       dataSources: Seq[DataSourceProfileResult],
       stages: Seq[StageAggTaskMetricsProfileResult],
-      graph: Option[ToolsPlanGraph])
+      graph: Option[ToolsPlanGraph],
+      properties: Map[String, String] = Map.empty)
     extends SingleAppSummaryInfoProvider(null, appSummary(dataSources, stages)) {
     override protected[tool] def planGraphForSqlVersion(
         sqlId: Long, version: Int): Option[ToolsPlanGraph] = graph
+    override def getAllProperties: Map[String, String] = properties
+    override def getSparkProperty(propKey: String): Option[String] = properties.get(propKey)
+    override def getRapidsProperty(propKey: String): Option[String] = properties.get(propKey)
+    override def getSystemProperty(propKey: String): Option[String] = None
+    override def getSparkVersion: Option[String] = Some(testSparkVersion)
+    override def scanStagesWithGpuOom: Set[Long] = Set.empty
+    override def getClassPathEntries: Map[String, String] = Map.empty
+  }
+
+  private def maxPartitionRecommendation(
+      provider: AppSummaryInfoBaseProvider,
+      helper: AutoTunerHelper,
+      properties: Map[String, String]): Option[String] = {
+    val platform = PlatformFactory.createInstance(PlatformNames.EMR)
+    platform.configureClusterInfoFromEventLog(
+      coresPerExecutor = 8,
+      execsPerNode = 1,
+      numExecs = 2,
+      numExecutorNodes = 2,
+      sparkProperties = properties,
+      systemProperties = Map.empty)
+    helper.buildAutoTunerFromProps(provider, platform).getRecommendedProperties()._1
+      .find(_.name == "spark.sql.files.maxPartitionBytes")
+      .map(_.getTuneValue())
   }
 
   test("base provider reports no reliable file scan input") {
@@ -185,19 +221,36 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
   test("qualification provider rejects the CI34 257 MiB cache-only input") {
     val graph = buildGraph(Seq(
       GraphNodeSpec(10L, "InMemoryTableScan", "InMemoryRelation cached", 20)))
+    val properties = Map(
+      "spark.master" -> "yarn",
+      "spark.executor.cores" -> "8",
+      "spark.executor.instances" -> "2",
+      "spark.executor.memory" -> "16g",
+      "spark.sql.files.maxPartitionBytes" -> "256m")
     val provider = new TestQualProvider(
-      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 257L * oneMiB, 500)), Some(graph))
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 257L * oneMiB, 500)), Some(graph),
+      properties)
 
     assert(provider.getMaxFileScanInput.isEmpty)
+    assert(maxPartitionRecommendation(
+      provider, QualificationAutoTunerHelper, properties).isEmpty)
   }
 
   test("profiling provider rejects the CI34 3140 MiB cache-only input") {
     val graph = buildGraph(Seq(
       GraphNodeSpec(10L, "InMemoryTableScan", "InMemoryRelation cached", 20)))
+    val properties = Map(
+      "spark.master" -> "yarn",
+      "spark.executor.cores" -> "8",
+      "spark.executor.instances" -> "2",
+      "spark.executor.memory" -> "16g",
+      "spark.sql.files.maxPartitionBytes" -> "254m")
     val provider = new TestProfilingProvider(
-      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 3140L * oneMiB, 96)), Some(graph))
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 3140L * oneMiB, 96)), Some(graph),
+      properties)
 
     assert(provider.getMaxFileScanInput.isEmpty)
+    assert(maxPartitionRecommendation(provider, ProfilingAutoTunerHelper, properties).isEmpty)
   }
 
   test("both concrete providers expose genuine file scan input") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
@@ -27,8 +27,8 @@ import com.nvidia.spark.rapids.tool.profiling.{ApplicationSummaryInfo, CollectIn
 import com.nvidia.spark.rapids.tool.views.RawMetricProfilerView
 
 import org.apache.spark.sql.rapids.tool.AccumToStageRetriever
-import org.apache.spark.sql.rapids.tool.plangraph.{SQLPlanMetric, SparkPlanGraph,
-  SparkPlanGraphNode, ToolsPlanGraph}
+import org.apache.spark.sql.rapids.tool.plangraph.{SparkPlanGraph, SparkPlanGraphNode,
+  SQLPlanMetric, ToolsPlanGraph}
 import org.apache.spark.sql.rapids.tool.profiling.ApplicationInfo
 import org.apache.spark.sql.rapids.tool.util.RapidsToolsConfUtil
 

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/FileScanInputMetricsSuite.scala
@@ -228,7 +228,7 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
       "spark.executor.memory" -> "16g",
       "spark.sql.files.maxPartitionBytes" -> "256m")
     val provider = new TestQualProvider(
-      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 257L * oneMiB, 500)), Some(graph),
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 269751712L, 500)), Some(graph),
       properties)
 
     assert(provider.getMaxFileScanInput.isEmpty)
@@ -246,7 +246,7 @@ class FileScanInputMetricsSuite extends ProfilingAutoTunerSuiteBase {
       "spark.executor.memory" -> "16g",
       "spark.sql.files.maxPartitionBytes" -> "254m")
     val provider = new TestProfilingProvider(
-      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 3140L * oneMiB, 96)), Some(graph),
+      Seq(dataSource(1L, 1, 10L)), Seq(stageMetric(20L, 3292825256L, 96)), Some(graph),
       properties)
 
     assert(provider.getMaxFileScanInput.isEmpty)

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -3284,7 +3284,7 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
     }
   }
 
-  test("test AutoTuner reduces maxPartitionBytes when scan stages have GPU OOM failures") {
+  test("test AutoTuner skips maxPartitionBytes when GPU OOM has no reliable scan baseline") {
     val eventLog = s"$profilingLogDir/gpu_oom_eventlog.zstd"
     TrampolineUtil.withTempDir { tempDir =>
       val appArgs = new ProfileArgs(Array(
@@ -3301,8 +3301,8 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
       val sparkProperties = FSUtils.readFileContentAsUTF8(sparkPropertiesFile)
       assert(sparkProperties.contains("\"spark.sql.files.maxPartitionBytes\",\"10gb\""))
 
-      // Compare the auto-tuner output to the expected results and assert that
-      // the maxPartitionBytes is reduced.
+      // This log has no final data-source-to-stage raw mapping, so the AutoTuner must not derive
+      // maxPartitionBytes from its global task input or use GPU OOM to establish a baseline.
       val logFile = getOutputFilePath(tempDir, "profile.log")
       val profileLogContent = FSUtils.readFileContentAsUTF8(logFile)
       val actualResults = extractAutoTunerResults(profileLogContent)
@@ -3323,7 +3323,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
             |--conf spark.rapids.sql.multiThreadedRead.numThreads=32
             |--conf spark.sql.adaptive.autoBroadcastJoinThreshold=[FILL_IN_VALUE]
             |--conf spark.sql.adaptive.coalescePartitions.initialPartitionNum=400
-            |--conf spark.sql.files.maxPartitionBytes=1851m
             |--conf spark.sql.shuffle.partitions=400
             |--conf spark.task.resource.gpu.amount=0.001
             |

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -49,6 +49,55 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
       .getOrCreate()
   }
 
+  private def maxPartitionRecommendation(
+      globalMaxInput: Double,
+      reliableFileScanInput: Option[Double],
+      currentValue: String,
+      scanStagesWithGpuOom: Set[Long] = Set.empty): Option[String] = {
+    val props = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "8",
+      "spark.executor.instances" -> "2",
+      "spark.executor.memory" -> "16g",
+      "spark.sql.files.maxPartitionBytes" -> currentValue)
+    val provider = getMockInfoProvider(
+      globalMaxInput,
+      Seq(0L),
+      Seq(0.0),
+      props,
+      Some(testSparkVersion),
+      scanStagesWithGpuOom = scanStagesWithGpuOom,
+      maxFileScanInputOverride = Some(reliableFileScanInput))
+    val platform = PlatformFactory.createInstance(PlatformNames.EMR)
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 8,
+      numWorkers = 2,
+      gpuCount = 1,
+      sparkProperties = props.toMap)
+    buildAutoTunerForTests(provider, platform).getRecommendedProperties()._1
+      .find(_.name == "spark.sql.files.maxPartitionBytes")
+      .map(_.getTuneValue())
+  }
+
+  test("profiling does not derive maxPartitionBytes from CI34 cache-only input") {
+    val ci34CacheInput = 3292825256.0
+
+    // The previous global-input calculation turned this cache read into 20m.
+    assert(maxPartitionRecommendation(ci34CacheInput, None, "254m").isEmpty)
+    assert(maxPartitionRecommendation(ci34CacheInput, Some(512.0 * 1024 * 1024), "1g")
+      .contains("512m"))
+  }
+
+  test("profiling GPU OOM adjustment requires a reliable file scan baseline") {
+    val scanOom = Set(20L)
+
+    assert(maxPartitionRecommendation(
+      3292825256.0, None, "512m", scanStagesWithGpuOom = scanOom).isEmpty)
+    assert(maxPartitionRecommendation(
+      0.0, Some(512.0 * 1024 * 1024), "1g", scanStagesWithGpuOom = scanOom)
+      .contains("512m"))
+  }
+
   // Test that the properties from the custom target cluster props will be enforced.
   test("AutoTuner enforces properties from custom target cluster props") {
     // 1. Mock source cluster info for dataproc

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -95,6 +95,72 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     }
   }
 
+  private def maxPartitionRecommendation(
+      globalMaxInput: Double,
+      reliableFileScanInput: Option[Double],
+      currentValue: String): Option[String] = {
+    val props = defaultSparkProps ++ mutable.Map(
+      "spark.sql.files.maxPartitionBytes" -> currentValue)
+    val provider = getMockInfoProvider(
+      globalMaxInput,
+      Seq(0L),
+      Seq(0.0),
+      props,
+      Some(testSparkVersion),
+      maxFileScanInputOverride = Some(reliableFileScanInput))
+    val platform = PlatformFactory.createInstance(PlatformNames.EMR)
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 32,
+      numWorkers = 5,
+      gpuCount = 4,
+      sparkProperties = props.toMap)
+    buildAutoTunerForTests(provider, platform).getRecommendedProperties()._1
+      .find(_.name == "spark.sql.files.maxPartitionBytes")
+      .map(_.getTuneValue())
+  }
+
+  test("qualification does not derive maxPartitionBytes from CI34 cache-only input") {
+    val ci34CacheInput = 269751712.0
+
+    // The previous global-input calculation turned this cache read into 254m.
+    assert(maxPartitionRecommendation(ci34CacheInput, None, "256m").isEmpty)
+    assert(maxPartitionRecommendation(ci34CacheInput, Some(512.0 * 1024 * 1024), "1g")
+      .contains("512m"))
+  }
+
+  test("qualification preserves EMR tuning for a mapped final Parquet scan fixture") {
+    val eventLog = s"$qualLogDir/nds_q72_dataproc_2_2.zstd"
+
+    TrampolineUtil.withTempDir { tempDir =>
+      val targetClusterInfoFile = ToolTestUtils.createTargetClusterInfoFile(
+        tempDir.getAbsolutePath,
+        cpuCores = Some(16),
+        memoryGB = Some(64L),
+        gpuCount = Some(1),
+        gpuDevice = Some(GpuTypes.L4))
+      val result = QualificationMain.mainInternal(new QualificationArgs(Array(
+        "--platform",
+        PlatformNames.EMR,
+        "--target-cluster-info",
+        targetClusterInfoFile.toString,
+        "--output-directory",
+        tempDir.getAbsolutePath,
+        "--auto-tuner",
+        eventLog)))
+
+      assert(!result.isFailed)
+      val appId = result.appSummaries.headOption.map(_.appId)
+        .getOrElse(throw new TestFailedException("No appId found in the result", 0))
+      val tuningResultPath = Paths.get(
+        QualReportGenConfProvider.getTuningReportPath(tempDir.getAbsolutePath),
+        s"$appId.log").toString
+      val tuningResults = FSUtils.readFileContentAsUTF8(tuningResultPath)
+
+      assert(tuningResults.contains("--conf spark.sql.files.maxPartitionBytes=1644m"))
+    }
+  }
+
   test("test AutoTuner for Qualification sets batch size to 1GB") {
     val autoTuner = buildDefaultAutoTuner()
     val (properties, comments) = autoTuner.getRecommendedProperties(showOnlyUpdatedProps =


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cudf-spark-tools/issues/2122

## Summary

- Derive `spark.sql.files.maxPartitionBytes` only from final, non-cache datasource scan stages.
- Share the provenance-aware input selector between qualification and profiling, including exact AQE plan-version binding.
- Skip synthesized recommendations when no reliable scan baseline exists while preserving configuration precedence and profiling GPU-OOM behavior after a valid baseline.

## Testing

- Scoped ScalaTest AutoTuner and cluster recommendation suites: 200 tests, 0 failures, 0 errors.


