### PR TITLE
Surface Spark application exit codes

### DIFF
--- a/core/src/main/resources/configs/reports/coreRawMetricsReport.yaml
+++ b/core/src/main/resources/configs/reports/coreRawMetricsReport.yaml
@@ -83,6 +83,10 @@ reportDefinitions:
             dataType: Long
             description: >-
               TBD
+          - name: exitCode
+            dataType: Int
+            description: >-
+              Spark application exit code, when recorded in the event log.
           - name: duration
             dataType: Long
             description: >-

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -458,6 +458,7 @@ case class AppInfoProfileResults(
     sparkUser: String,
     startTime: Long,
     endTime: Option[Long],
+    exitCode: Option[Int],
     duration: Option[Long],
     durationStr: String,
     sparkRuntime: SparkRuntime.SparkRuntime,
@@ -482,6 +483,10 @@ case class AppInfoProfileResults(
     }
   }
 
+  private def exitCodeToStr: String = {
+    exitCode.map(_.toString).getOrElse("")
+  }
+
   private def appIdToStr: String = {
     appId match {
       case Some(t) => t
@@ -498,7 +503,7 @@ case class AppInfoProfileResults(
 
   override def convertToSeq(): Array[String] = {
     Array(appName, appIdToStr, attemptIdToStr,
-      sparkUser, startTime.toString, endTimeToStr, durToStr,
+      sparkUser, startTime.toString, endTimeToStr, exitCodeToStr, durToStr,
       durationStr, sparkRuntime.toString, sparkVersion, pluginEnabled.toString,
       totalCoreSeconds.toString)
   }
@@ -508,7 +513,8 @@ case class AppInfoProfileResults(
       StringUtils.reformatCSVString(appIdToStr),
       StringUtils.reformatCSVString(attemptIdToStr),
       StringUtils.reformatCSVString(sparkUser),
-      startTime.toString, endTimeToStr, durToStr, StringUtils.reformatCSVString(durationStr),
+      startTime.toString, endTimeToStr, exitCodeToStr, durToStr,
+      StringUtils.reformatCSVString(durationStr),
       StringUtils.reformatCSVString(sparkRuntime.toString),
       StringUtils.reformatCSVString(sparkVersion),
       pluginEnabled.toString,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/profiling/ProfileClassWarehouse.scala
@@ -458,7 +458,7 @@ case class AppInfoProfileResults(
     sparkUser: String,
     startTime: Long,
     endTime: Option[Long],
-    exitCode: Option[Int],
+    exitCode: Option[Int] = None,
     duration: Option[Long],
     durationStr: String,
     sparkRuntime: SparkRuntime.SparkRuntime,

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/InformationView.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ trait AppInformationViewTrait extends ViewableTrait[AppInfoProfileResults] {
   def getRawView(app: AppBase, index: Int): Seq[AppInfoProfileResults] = {
     app.appMetaData.map { a =>
       AppInfoProfileResults(a.appName, a.appId, Option(a.attemptId),
-        a.sparkUser, a.startTime, a.endTime, app.getAppDuration,
+        a.sparkUser, a.startTime, a.endTime, app.getAppExitCode, app.getAppDuration,
         a.getDurationString, app.getSparkRuntime, app.sparkVersion, app.gpuMode,
         app.totalCoreSeconds)
     }.toSeq

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/views/OutHeaderRegistry.scala
@@ -68,8 +68,9 @@ object OutHeaderRegistry {
     "UnsupportedOpsProfileResult" ->
       Array("sqlID", "nodeID", "nodeName", "nodeDescription", "reason"),
     "AppInfoProfileResults" ->
-      Array("appName", "appId", "attemptId", "sparkUser", "startTime", "endTime", "duration",
-        "durationStr", "sparkRuntime", "sparkVersion", "pluginEnabled", "totalCoreSeconds"),
+      Array("appName", "appId", "attemptId", "sparkUser", "startTime", "endTime", "exitCode",
+        "duration", "durationStr", "sparkRuntime", "sparkVersion", "pluginEnabled",
+        "totalCoreSeconds"),
     "AppLevelRecommendationSignalsProfileResult" ->
       Array("appId", "numScanStagesWithGpuOom", "numGpuShuffleStagesWithContainerOom"),
     "AppLogPathProfileResults" ->

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppBase.scala
@@ -34,7 +34,7 @@ import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.deploy.history.{EventLogFileReader, EventLogFileWriter}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rapids.tool.benchmarks.RuntimeInjector
-import org.apache.spark.scheduler.{SparkListenerEvent, StageInfo}
+import org.apache.spark.scheduler.{SparkListenerApplicationEnd, SparkListenerEvent, StageInfo}
 import org.apache.spark.sql.rapids.tool.plangraph.{SparkPlanGraphNode, ToolsPlanGraph}
 import org.apache.spark.sql.rapids.tool.store.{AccumManager, DataSourceRecord, SparkPlanInfoTruncated, SQLPlanModel, SQLPlanModelManager, StageModel, StageModelManager, TaskModelManager, WriteOperationRecord}
 import org.apache.spark.sql.rapids.tool.util.{CacheablePropsHandler, EventUtils, RapidsToolsConfUtil, StringUtils, SuccessAppResult, UTF8Source}
@@ -165,6 +165,14 @@ abstract class AppBase(
   // This is called while handling ApplicationEnd event
   def updateEndTime(newEndTime: Long): Unit = {
     appMetaData.foreach(_.setEndTime(newEndTime))
+  }
+
+  def updateExitCode(exitCode: Int): Unit = {
+    appMetaData.foreach(_.setExitCode(exitCode))
+  }
+
+  def getAppExitCode: Option[Int] = {
+    appMetaData.flatMap(_.exitCode)
   }
 
   // Returns a boolean flag to indicate whether the endTime was estimated.
@@ -360,7 +368,16 @@ abstract class AppBase(
                 // Do NOT use a while loop as it is much much slower.
                 totalNumEvents += 1
                 runtimeGetFromJsonMethod.apply(line) match {
-                  case Some(e) => processEvent(e)
+                  case Some(e) =>
+                    val stopProcessing = processEvent(e)
+                    // Spark 4 adds ExitCode to SparkListenerApplicationEnd. Read it from the raw
+                    // JSON so Spark 3 runtimes can also retain it when parsing Spark 4 event logs.
+                    e match {
+                      case _: SparkListenerApplicationEnd =>
+                        EventUtils.readApplicationExitCode(line).foreach(updateExitCode)
+                      case _ =>
+                    }
+                    stopProcessing
                   case None => false
                 }
               }

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/AppMetaData.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.apache.spark.ui.UIUtils
  * @param startTime startTime of a Spark application
  * @param endTime endTime of the spark Application
  * @param attemptId attemptId of the application
+ * @param exitCode application exit code, when recorded in the event log
  */
 class AppMetaData(
     val eventLogPath: Option[String],
@@ -40,7 +41,8 @@ class AppMetaData(
     val sparkUser: String,
     val startTime: Long,
     var endTime: Option[Long] = None,
-    var attemptId: Int = 1) extends Identifiable[String] {
+    var attemptId: Int = 1,
+    var exitCode: Option[Int] = None) extends Identifiable[String] {
 
   // A private field to store the default identifier for the application.
   // This is derived from the event log path.
@@ -103,6 +105,10 @@ class AppMetaData(
 
   def setAttemptId(attemptId: Int): Unit = {
     this.attemptId = attemptId
+  }
+
+  def setExitCode(exitCode: Int): Unit = {
+    this.exitCode = Some(exitCode)
   }
 
   // Initialization code:

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/ToolUtils.scala
@@ -27,7 +27,6 @@ import com.nvidia.spark.rapids.tool.qualification.QualOutputWriter
 import org.apache.maven.artifact.versioning.ComparableVersion
 
 import org.apache.spark.internal.{config, Logging}
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.rapids.tool.plangraph.SparkPlanGraphNode
 import org.apache.spark.sql.rapids.tool.util.SparkRuntime
 
@@ -125,10 +124,6 @@ object ToolUtils extends Logging {
       properties.getOrElse("spark.rapids.sql.enabled", "true").toBoolean
     }.getOrElse(true) // Default to true if parsing fails, matching the default value
     hasPlugin && isEnabled
-  }
-
-  def showString(df: DataFrame, numRows: Int) = {
-    df.showString(numRows, 0)
   }
 
   /**

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -23,6 +23,7 @@ import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 import scala.util.matching.Regex
 
+import org.json4s.JInt
 import org.json4s.jackson.JsonMethods.parse
 
 import org.apache.spark.internal.Logging
@@ -35,6 +36,13 @@ object EventUtils extends Logging {
   // A valid Spark catalog name must start with a letter, can contain letters, digits,
   // underscores, or dashes, and must not end with a dot.
   val SPARK_CATALOG_REGEX: Regex = """spark\\.sql\\.catalog\\.([A-Za-z][A-Za-z0-9_-]*)$""".r
+
+  /** Reads Spark 4's optional application exit code without depending on Spark 4 classes. */
+  def readApplicationExitCode(line: String): Option[Int] = {
+    Try(parse(line) \ "ExitCode").toOption.collect {
+      case JInt(value) if value.isValidInt => value.toInt
+    }
+  }
 
   // Set to keep track of missing classes
   private val missingEventClasses = mutable.HashSet[String]()

--- a/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
+++ b/core/src/main/scala/org/apache/spark/sql/rapids/tool/util/EventUtils.scala
@@ -37,7 +37,13 @@ object EventUtils extends Logging {
   // underscores, or dashes, and must not end with a dot.
   val SPARK_CATALOG_REGEX: Regex = """spark\\.sql\\.catalog\\.([A-Za-z][A-Za-z0-9_-]*)$""".r
 
-  /** Reads Spark 4's optional application exit code without depending on Spark 4 classes. */
+  /**
+   * Reads Spark 4's optional application exit code without depending on Spark 4 classes.
+   *
+   * TODO: Remove this JSON fallback and use SparkListenerApplicationEnd.exitCode when all
+   * supported Tools builds use Spark 4 or later.
+   * See https://github.com/NVIDIA/cudf-spark-tools/issues/1927.
+   */
   def readApplicationExitCode(line: String): Option[Int] = {
     Try(parse(line) \ "ExitCode").toOption.collect {
       case JInt(value) if value.isValidInt => value.toInt

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/profiling/ApplicationInfoSuite.scala
@@ -1362,4 +1362,45 @@ class ApplicationInfoSuite extends AnyFunSuite with Logging {
         "spark.sql.autoBroadcastJoinThreshold", "") == "10485760")
     }
   }
+
+  test("application exit code is parsed when present") {
+    Seq(0, 13).foreach { exitCode =>
+      TrampolineUtil.withTempDir { tempDir =>
+        val eventLogFilePath = Paths.get(tempDir.getAbsolutePath, "test_eventlog")
+        // scalastyle:off line.size.limit
+        val eventLogContent =
+          s"""{"Event":"SparkListenerLogStart","Spark Version":"4.0.2"}
+            |{"Event":"SparkListenerApplicationStart","App Name":"ExitCode_Test","App ID":"local-exit-code-test","Timestamp":123456,"User":"testUser"}
+            |{"Event":"SparkListenerApplicationEnd","Timestamp":123460,"ExitCode":$exitCode}"""
+            .stripMargin
+        // scalastyle:on line.size.limit
+        Files.write(eventLogFilePath, eventLogContent.getBytes(StandardCharsets.UTF_8))
+
+        val app = new ApplicationInfo(hadoopConf,
+          EventLogPathProcessor.getEventLogInfo(
+            eventLogFilePath.toString, hadoopConf).head._1)
+
+        assert(app.getAppExitCode.contains(exitCode))
+      }
+    }
+  }
+
+  test("application exit code is unknown when absent") {
+    TrampolineUtil.withTempDir { tempDir =>
+      val eventLogFilePath = Paths.get(tempDir.getAbsolutePath, "test_eventlog")
+      // scalastyle:off line.size.limit
+      val eventLogContent =
+        """{"Event":"SparkListenerLogStart","Spark Version":"3.5.7"}
+          |{"Event":"SparkListenerApplicationStart","App Name":"Legacy_Test","App ID":"local-legacy-test","Timestamp":123456,"User":"testUser"}
+          |{"Event":"SparkListenerApplicationEnd","Timestamp":123460}""".stripMargin
+      // scalastyle:on line.size.limit
+      Files.write(eventLogFilePath, eventLogContent.getBytes(StandardCharsets.UTF_8))
+
+      val app = new ApplicationInfo(hadoopConf,
+        EventLogPathProcessor.getEventLogInfo(
+          eventLogFilePath.toString, hadoopConf).head._1)
+
+      assert(app.getAppExitCode.isEmpty)
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Surface Spark's optional application exit code in `application_information.csv` for both Profiling and Qualification. This distinguishes the Spark application's outcome from the existing Tools processing status, whose `SUCCESS` value only means the event log was processed successfully.

Spark 4 adds `ExitCode` to `SparkListenerApplicationEnd`, but the default Spark 3 Tools runtime discards unknown fields during event deserialization. The implementation therefore reads the optional value from the raw application-end JSON without taking a compile-time dependency on the Spark 4 API.

- `0` records a successful Spark application.
- A nonzero value records a failed Spark application.
- A missing value remains blank for older event logs.

## Validation

- `ApplicationInfoSuite`: 55 tests passed with the default Spark 3.5.7 build, covering exit codes `0`, `13`, and a missing value.
- `mvn clean package -DskipTests` passed with the default Spark 3.5.7 / Scala 2.12 configuration.
- Spark 4.0.2 / Scala 2.13 production compilation passed.
- Profiling and Qualification CLI runs on a Spark 4 event log emitted `exitCode=0`.
- Qualification with the default Spark 3.5.7 runtime also extracted `ExitCode` from the Spark 4 log.
- Qualification on a Spark 3.1.3 event log completed successfully and emitted a blank exit code.

Fixes #2120
