### PR TITLE
Fix CSP memory overhead sizing with host off-heap limit

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -296,6 +296,12 @@ abstract class AutoTuner(
       .exists(_.trim.equalsIgnoreCase("true"))
   }
 
+  /**
+   * Whether AutoTuner can use the specialized host off-heap sizing path.
+   *
+   * CSPs do not support that sizing formula, so they must retain the normal budget-aware overhead
+   * path even when the host off-heap limit property is enabled.
+   */
   private lazy val useHostOffHeapLimitSizing: Boolean = {
     !platform.isPlatformCSP && isOffHeapLimitUserEnabled
   }
@@ -1067,7 +1073,8 @@ abstract class AutoTuner(
     )
     val pySparkMemMB = pySparkMemoryAdjustment.map(_.layoutCurrentMB)
       .getOrElse(platform.getPySparkMemoryMB(getPropertyValue).getOrElse(0L))
-    // Calculate executor memory overhead using new formula if OffHeapLimit.enabled=true
+    // Keep this calculation and final overhead selection on the same sizing path. Otherwise a CSP
+    // could skip the specialized calculation here but still bypass budget-aware overhead below.
     val executorMemOverhead = if (useHostOffHeapLimitSizing) {
       calculateExecutorMemoryOverhead(
         totalMemMinusReserved, executorHeapMB, sparkOffHeapMemMB)
@@ -1153,6 +1160,8 @@ abstract class AutoTuner(
           executorMemOverhead + defaultPinnedMem + defaultSpillMem
         }
       }
+      // Normal sizing includes pinned and spill pools in container overhead. Specialized sizing
+      // budgets those pools under the host off-heap limit, so only JVM overhead is protected here.
       val protectedOverheadFloorMB = if (useHostOffHeapLimitSizing) {
         executorMemOverhead
       } else {

--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/tuning/AutoTuner.scala
@@ -296,6 +296,10 @@ abstract class AutoTuner(
       .exists(_.trim.equalsIgnoreCase("true"))
   }
 
+  private lazy val useHostOffHeapLimitSizing: Boolean = {
+    !platform.isPlatformCSP && isOffHeapLimitUserEnabled
+  }
+
   private lazy val sparkMaster: Option[SparkMaster] = {
     SparkMaster(appInfoProvider.getProperty("spark.master"))
   }
@@ -1064,7 +1068,7 @@ abstract class AutoTuner(
     val pySparkMemMB = pySparkMemoryAdjustment.map(_.layoutCurrentMB)
       .getOrElse(platform.getPySparkMemoryMB(getPropertyValue).getOrElse(0L))
     // Calculate executor memory overhead using new formula if OffHeapLimit.enabled=true
-    val executorMemOverhead = if (isOffHeapLimitUserEnabled) {
+    val executorMemOverhead = if (useHostOffHeapLimitSizing) {
       calculateExecutorMemoryOverhead(
         totalMemMinusReserved, executorHeapMB, sparkOffHeapMemMB)
     } else {
@@ -1075,7 +1079,7 @@ abstract class AutoTuner(
     val defaultPinnedMem = configProvider.getEntry("PINNED_MEMORY").getDefaultAsMemory(ByteUnit.MiB)
     val defaultSpillMem = configProvider.getEntry("SPILL_MEMORY").getDefaultAsMemory(ByteUnit.MiB)
     val minOverhead: Long = baselineMemorySettings.executorMemOverhead.getOrElse {
-      if (isOffHeapLimitUserEnabled) {
+      if (useHostOffHeapLimitSizing) {
         executorMemOverhead
       } else {
         executorMemOverhead + defaultPinnedMem + defaultSpillMem
@@ -1089,8 +1093,7 @@ abstract class AutoTuner(
       // memory to core ratio
       // Calculate host off-heap limit size for pinned memory calculation
       // (only for onPrem when offHeapLimit is enabled)
-      val hostOffHeapLimitSizeMB = if (!platform.isPlatformCSP &&
-        isOffHeapLimitUserEnabled) {
+      val hostOffHeapLimitSizeMB = if (useHostOffHeapLimitSizing) {
         val userOffHeapLimitOpt =
           getBaselineSparkProperty("spark.rapids.memory.host.offHeapLimit.size")
         if (userOffHeapLimitOpt.isDefined) {
@@ -1106,7 +1109,7 @@ abstract class AutoTuner(
 
       // Pinned memory calculation - use new formula for onPrem, original logic for CSP
       var pinnedMem = baselineMemorySettings.pinnedMem.getOrElse {
-        if (!platform.isPlatformCSP && hostOffHeapLimitSizeMB > 0) {
+        if (useHostOffHeapLimitSizing && hostOffHeapLimitSizeMB > 0) {
           // Use new formula for onPrem platform
           calculatePinnedMemorySize(numExecutorCores, hostOffHeapLimitSizeMB)
         } else {
@@ -1120,7 +1123,7 @@ abstract class AutoTuner(
       // all off heap memory.
       var spillMem = baselineMemorySettings.spillMem.getOrElse(pinnedMem)
       var finalExecutorMemOverhead = baselineMemorySettings.executorMemOverhead.getOrElse {
-        if (isOffHeapLimitUserEnabled) {
+        if (useHostOffHeapLimitSizing) {
           executorMemOverhead
         } else {
           // Budget-aware: claim the full available memory (execMemLeft) as overhead
@@ -1144,13 +1147,13 @@ abstract class AutoTuner(
         // Else update pinned and spill memory to use default values
         pinnedMem = defaultPinnedMem
         spillMem = defaultSpillMem
-        finalExecutorMemOverhead = if (isOffHeapLimitUserEnabled) {
+        finalExecutorMemOverhead = if (useHostOffHeapLimitSizing) {
           executorMemOverhead
         } else {
           executorMemOverhead + defaultPinnedMem + defaultSpillMem
         }
       }
-      val protectedOverheadFloorMB = if (isOffHeapLimitUserEnabled) {
+      val protectedOverheadFloorMB = if (useHostOffHeapLimitSizing) {
         executorMemOverhead
       } else {
         executorMemOverhead + pinnedMem + spillMem
@@ -1518,7 +1521,7 @@ abstract class AutoTuner(
 
               // Calculate host off-heap limit size for onPrem platform only when
               // offHeapLimit is enabled
-              if (!platform.isPlatformCSP && isOffHeapLimitUserEnabled) {
+              if (useHostOffHeapLimitSizing) {
                 val hostOffHeapLimitSizeMB = recomMemorySettings.executorMemOverhead.get +
                   offHeapSizeMB - nonExecutorMemory
                 if (hostOffHeapLimitSizeMB > 0) {
@@ -1541,8 +1544,8 @@ abstract class AutoTuner(
               appendCommentForNotEnoughMem("spark.executor.memoryOverhead")
             }
             appendCommentForNotEnoughMem("spark.executor.memory")
-            // Skip off-heap related comments when offHeapLimit is enabled
-            if (!platform.isPlatformCSP && isOffHeapLimitUserEnabled) {
+            // Add off-heap sizing comments only when that sizing path is active.
+            if (useHostOffHeapLimitSizing) {
               appendCommentForNotEnoughMem("spark.memory.offHeap.size")
               appendCommentForNotEnoughMem("spark.rapids.memory.host.offHeapLimit.size")
             }
@@ -2398,7 +2401,7 @@ abstract class AutoTuner(
   private def calculatePinnedMemorySize(numExecutorCores: Int,
                                         hostOffHeapLimitSizeMB: Long): Long = {
     // Use new formula only for onPrem platform
-    if (!platform.isPlatformCSP && isOffHeapLimitUserEnabled) {
+    if (useHostOffHeapLimitSizing) {
       // Calculate pinned pool-offHeap ratio * host.offHeapLimit.Size
       val ratioPinnedPoolSize = hostOffHeapLimitSizeMB *
         configProvider.getEntry("PINNED_MEM_OFFHEAP_RATIO").getDefault.toDouble
@@ -2428,7 +2431,7 @@ abstract class AutoTuner(
     offHeapMB: Long): Long = {
 
     // Use new formula only for onPrem platform when offHeapLimit is enabled
-    if (!platform.isPlatformCSP && isOffHeapLimitUserEnabled) {
+    if (useHostOffHeapLimitSizing) {
       val calculatedOverhead = totalMemMinusReserved - executorHeapMB - offHeapMB
 
       // Ensure the overhead is not negative and has a minimum value

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/BaseAutoTunerSuite.scala
@@ -20,9 +20,9 @@ import java.io.File
 
 import scala.collection.mutable
 
-import com.nvidia.spark.rapids.tool.{DynamicAllocationInfo, Platform, PlatformFactory, PlatformNames, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.{DynamicAllocationInfo, GpuTypes, Platform, PlatformFactory, PlatformNames, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.profiling._
-import com.nvidia.spark.rapids.tool.tuning.config.TuningConfiguration
+import com.nvidia.spark.rapids.tool.tuning.config.{TuningConfigEntry, TuningConfiguration}
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.exceptions.TestFailedException
 import org.scalatest.funsuite.AnyFunSuite
@@ -236,6 +236,55 @@ abstract class BaseAutoTunerSuite extends AnyFunSuite with BeforeAndAfterEach
     // Build and return the AutoTuner
     autoTunerHelper.buildAutoTunerFromProps(mockInfoProvider, platform,
       userProvidedTuningConfigs = userProvidedTuningConfigs)
+  }
+
+  /**
+   * Runs the common executor-memory sizing scenario used to verify host off-heap limit behavior.
+   */
+  protected def getHostOffHeapLimitMemoryRecommendations(
+      platformName: String,
+      offHeapLimitEnabled: Boolean,
+      pySparkMemory: Option[String] = None,
+      explicitExecutorOverhead: Option[String] = None): Map[String, String] = {
+    val sourceProps = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "16",
+      "spark.executor.instances" -> "2",
+      "spark.executor.memory" -> "32g",
+      "spark.executor.resource.gpu.amount" -> "1",
+      "spark.plugins" -> "com.nvidia.spark.SQLPlugin",
+      "spark.rapids.sql.enabled" -> "true")
+    pySparkMemory.foreach(sourceProps.put("spark.executor.pyspark.memory", _))
+
+    val enforcedProps = mutable.LinkedHashMap[String, String](
+      "spark.executor.cores" -> "16",
+      "spark.executor.memory" -> "32g")
+    if (offHeapLimitEnabled) {
+      enforcedProps.put("spark.rapids.memory.host.offHeapLimit.enabled", "true")
+    }
+    explicitExecutorOverhead.foreach(
+      enforcedProps.put("spark.executor.memoryOverhead", _))
+
+    val targetClusterInfo = ToolTestUtils.buildTargetClusterInfo(
+      cpuCores = Some(16),
+      memoryGB = Some(64L),
+      gpuCount = Some(1),
+      gpuDevice = Some(GpuTypes.L4.toString),
+      enforcedSparkProperties = enforcedProps.toMap)
+    val infoProvider = getMockInfoProvider(
+      0, Seq(0), Seq(0.0), sourceProps, Some(testSparkVersion))
+    val platform = PlatformFactory.createInstance(platformName, Some(targetClusterInfo))
+    configureEventLogClusterInfoForTest(
+      platform,
+      numCores = 16,
+      numWorkers = 2,
+      sparkProperties = sourceProps.toMap)
+    val tuningConfigs = ToolTestUtils.buildTuningConfigs(default = List(
+      TuningConfigEntry(name = "NON_EXECUTOR_MEM_FRACTION", default = "0.25")))
+
+    val autoTuner = buildAutoTunerForTests(
+      infoProvider, platform, Some(Yarn), Some(tuningConfigs))
+    autoTuner.getRecommendedProperties(showOnlyUpdatedProps = false)._1
+      .map(property => property.name -> property.getTuneValue()).toMap
   }
 
   /**

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -2509,6 +2509,35 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
         s"memoryOverhead with preserve=$overheadWith vs without=$overheadWithout")
   }
 
+  // CSPs must use budget-aware overhead even when host off-heap limit is enabled.
+  forAll(Table(
+      ("platform", "offHeapLimitEnabled", "pySparkMemory", "expectedOverhead", "expectedPinned"),
+      (PlatformNames.EMR, false, Some("4g"), "12g", "4506m"),
+      (PlatformNames.EMR, true, Some("4g"), "12g", "4506m"),
+      (PlatformNames.ONPREM, false, None, "16g", "6554m"),
+      (PlatformNames.ONPREM, true, None, "16g", "8g"))) {
+    (platform: String, offHeapLimitEnabled: Boolean, pySparkMemory: Option[String],
+        expectedOverhead: String, expectedPinned: String) =>
+      test(s"Profiling uses the correct memory sizing path on $platform when " +
+          s"host off-heap limit enabled is $offHeapLimitEnabled") {
+        val recommendations = getHostOffHeapLimitMemoryRecommendations(
+          platform, offHeapLimitEnabled, pySparkMemory)
+
+        assert(recommendations.get("spark.executor.memoryOverhead").contains(expectedOverhead))
+        assert(recommendations.get("spark.rapids.memory.pinnedPool.size").contains(expectedPinned))
+      }
+  }
+
+  test("Profiling preserves explicit CSP executor overhead with host off-heap limit enabled") {
+    val recommendations = getHostOffHeapLimitMemoryRecommendations(
+      PlatformNames.EMR,
+      offHeapLimitEnabled = true,
+      pySparkMemory = Some("4g"),
+      explicitExecutorOverhead = Some("6g"))
+
+    assert(recommendations.get("spark.executor.memoryOverhead").contains("6g"))
+  }
+
   // Issue #2053: host off-heap limit settings affect pinned-memory sizing on on-prem
   // clusters, so preserved source values must be used as calculation baselines.
   test("preserved host off-heap limit settings are used as memory sizing baselines") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/QualificationAutoTunerSuite.scala
@@ -744,6 +744,35 @@ class QualificationAutoTunerSuite extends BaseAutoTunerSuite {
     }
   }
 
+  // CSPs must use budget-aware overhead even when host off-heap limit is enabled.
+  forAll(Table(
+      ("platform", "offHeapLimitEnabled", "pySparkMemory", "expectedOverhead", "expectedPinned"),
+      (PlatformNames.EMR, false, Some("4g"), "12g", "4506m"),
+      (PlatformNames.EMR, true, Some("4g"), "12g", "4506m"),
+      (PlatformNames.ONPREM, false, None, "16g", "6554m"),
+      (PlatformNames.ONPREM, true, None, "16g", "8g"))) {
+    (platform: String, offHeapLimitEnabled: Boolean, pySparkMemory: Option[String],
+        expectedOverhead: String, expectedPinned: String) =>
+      test(s"Qualification uses the correct memory sizing path on $platform when " +
+          s"host off-heap limit enabled is $offHeapLimitEnabled") {
+        val recommendations = getHostOffHeapLimitMemoryRecommendations(
+          platform, offHeapLimitEnabled, pySparkMemory)
+
+        assert(recommendations.get("spark.executor.memoryOverhead").contains(expectedOverhead))
+        assert(recommendations.get("spark.rapids.memory.pinnedPool.size").contains(expectedPinned))
+      }
+  }
+
+  test("Qualification preserves explicit CSP executor overhead with host off-heap limit enabled") {
+    val recommendations = getHostOffHeapLimitMemoryRecommendations(
+      PlatformNames.EMR,
+      offHeapLimitEnabled = true,
+      pySparkMemory = Some("4g"),
+      explicitExecutorOverhead = Some("6g"))
+
+    assert(recommendations.get("spark.executor.memoryOverhead").contains("6g"))
+  }
+
   /**
    * Test to validate onPrem platform with offHeapLimit enabled.
    * This tests the new memory calculation logic with NON_EXECUTOR_MEM and offHeapLimit features.


### PR DESCRIPTION
## Summary

There was a discrepancy in how AutoTuner handled `spark.rapids.memory.host.offHeapLimit.enabled` on CSP platforms: it skipped the specialized sizing calculation but finalized memory as if that calculation had run. This left only the JVM minimum instead of budget-aware executor overhead. The change uses one effective predicate for both decisions while preserving explicit overhead values and existing non-CSP behavior.

Fixes #2135.

## Test plan

- `QualificationAutoTunerSuite`: 55 tests passed.
- `ProfilingAutoTunerSuiteV2`: 71 tests passed.
- Scalastyle: 316 files checked, 0 errors and 0 warnings.

## Scope

This change does not modify `maxBytesInFlight` handling.

## Post-deploy Monitoring & Validation

No additional operational monitoring is required. The change affects offline AutoTuner recommendations and is covered by the Qualification and Profiling suites above.
