### PR TITLE
Handle a zero-worker Databricks cluster in _init_nodes

### DIFF
--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_aws.py
@@ -193,7 +193,8 @@ class DatabricksCluster(ClusterBase):
     def _init_nodes(self):
         # assume that only one master node
         master_nodes_from_conf = self.props.get_value_silent('driver')
-        worker_nodes_from_conf = self.props.get_value_silent('executors')
+        # a zero-worker (single-node) cluster has no `executors` entry at all
+        worker_nodes_from_conf = self.props.get_value_silent('executors') or []
         num_workers = self.props.get_value_silent('num_workers')
         if num_workers is None and self.props.get_value_silent('autoscale') is not None:
             target_workers = self.props.get_value_silent('autoscale', 'target_workers')

--- a/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
+++ b/user_tools/src/spark_rapids_pytools/cloud_api/databricks_azure.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -244,7 +244,8 @@ class DatabricksAzureCluster(ClusterBase):
     def _init_nodes(self):
         # assume that only one driver node
         driver_nodes_from_conf = self.props.get_value_silent('driver')
-        worker_nodes_from_conf = self.props.get_value_silent('executors')
+        # a zero-worker (single-node) cluster has no `executors` entry at all
+        worker_nodes_from_conf = self.props.get_value_silent('executors') or []
         num_workers = self.props.get_value_silent('num_workers')
         if num_workers is None and self.props.get_value_silent('autoscale') is not None:
             target_workers = self.props.get_value_silent('autoscale', 'target_workers')

--- a/user_tools/tests/spark_rapids_tools_ut/test_cluster.py
+++ b/user_tools/tests/spark_rapids_tools_ut/test_cluster.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2025, NVIDIA CORPORATION.
+# Copyright (c) 2023-2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,12 +14,21 @@
 
 """Test Identifying cluster from properties"""
 
+import json
+
 import pytest
 
+from spark_rapids_pytools.cloud_api.sp_types import CspEnv, get_platform
+from spark_rapids_pytools.common.prop_manager import JSONPropertiesContainer
 from spark_rapids_tools import CspPath
 from spark_rapids_tools.cloud import ClientCluster
 from spark_rapids_tools.exceptions import InvalidPropertiesSchema
 from .conftest import SparkRapidsToolsUT, all_cpu_cluster_props
+
+databricks_cluster_props = [
+    pytest.param(CspEnv.DATABRICKS_AWS, 'cluster/databricks/aws-cpu-00.json', id='databricks_aws'),
+    pytest.param(CspEnv.DATABRICKS_AZURE, 'cluster/databricks/azure-cpu-00.json', id='databricks_azure')
+]
 
 
 class TestClusterCSP(SparkRapidsToolsUT):  # pylint: disable=too-few-public-methods
@@ -36,3 +45,32 @@ class TestClusterCSP(SparkRapidsToolsUT):  # pylint: disable=too-few-public-meth
     def test_define_cluster_type_from_schema(self, csp, prop_path, get_ut_data_dir):
         client_cluster = ClientCluster(CspPath(f'{get_ut_data_dir}/{prop_path}'))
         assert client_cluster.platform_name == csp
+
+
+class TestDatabricksClusterWorkers(SparkRapidsToolsUT):  # pylint: disable=too-few-public-methods
+    """
+    Class testing how the Databricks platforms build the worker nodes of a cluster from its
+    `clusters get` properties when the `executors` entry is absent, which is what the API
+    returns for a zero-worker (single-node) cluster and for a terminated cluster
+    """
+    @staticmethod
+    def _load_cluster(csp_enum, prop_path, data_dir, num_workers):
+        with open(f'{data_dir}/{prop_path}', encoding='utf8') as prop_file:
+            props = json.load(prop_file)
+        props.pop('executors', None)
+        props['num_workers'] = num_workers
+        platform = get_platform(csp_enum)(ctxt_args={})
+        return platform.load_cluster_by_prop(JSONPropertiesContainer(prop_arg=props, file_load=False))
+
+    @pytest.mark.parametrize('csp_enum,prop_path', databricks_cluster_props)
+    def test_zero_worker_cluster_raises_no_workers_error(self, csp_enum, prop_path, get_ut_data_dir):
+        # a single-node cluster has num_workers 0 and no executors entry; the platform's own
+        # "no worker nodes" error is the expected answer, not a TypeError from iterating None
+        with pytest.raises(RuntimeError, match='The cluster has no worker nodes'):
+            self._load_cluster(csp_enum, prop_path, get_ut_data_dir, num_workers=0)
+
+    @pytest.mark.parametrize('csp_enum,prop_path', databricks_cluster_props)
+    def test_terminated_cluster_generates_workers(self, csp_enum, prop_path, get_ut_data_dir):
+        # a terminated multi-node cluster has no executors entry either; its workers are generated
+        cluster = self._load_cluster(csp_enum, prop_path, get_ut_data_dir, num_workers=2)
+        assert cluster.get_workers_count() == 2


### PR DESCRIPTION
Fixes #2143

## Problem

`spark_rapids qualification --cluster <id>` (and `profiling`, same path) on a Databricks
single-node cluster died with `TypeError: 'NoneType' object is not iterable` in `_init_nodes`.
`databricks clusters get` returns no `executors` entry for a cluster with no workers, and the
guard from #964 only regenerates the worker list when `num_workers` differs from the executor
count, which is 0 in both cases. The intended answer for this shape, the `RuntimeError`
"Invalid cluster: The cluster has no worker nodes" added in #240, never ran because
`_init_nodes` crashes before `_verify_workers_exist`.

A zero-worker cluster as `databricks clusters get` returns it (trimmed):

```json
{"cluster_id": "...", "state": "TERMINATED", "num_workers": 0, "node_type_id": "Standard_NC16as_T4_v3",
 "driver_node_type_id": "Standard_NC16as_T4_v3",
 "spark_conf": {"spark.databricks.cluster.profile": "singleNode", "spark.master": "local[*, 4]"},
 "custom_tags": {"ResourceClass": "SingleNode"}}
```

## Fix

`_init_nodes` in the Azure and AWS platform classes reads `executors` as an empty list when the
entry is absent, the same line in the same place in both files, right after the `driver` read
(`driver` gets its own absent-entry branch further down in the same method).

- The count stays 0, the guard is unchanged, the loop is a no-op and `_verify_workers_exist`
  raises the intended error. This restores the error, not single-node support; #2143 notes
  driver-only evaluation as a separate request.
- Every shape with a nonzero worker count (terminated multi-node, autoscaling, `executors`
  present, `executors` empty) takes the path it takes today with the same log lines. Props
  with none of `num_workers`, `autoscale` and `executors` also move from the `TypeError` to
  the same `RuntimeError`.
- Widening the guard instead would have logged "Cluster configuration: `executors` count 0
  does not match the `num_workers` value 0. Using generated names." on the zero-worker path.
  `ClusterBase._process_loaded_props` is the hook for cleaning loaded properties (`emr.py`
  unwraps its `Cluster` wrapper there); neither Databricks class overrides it, so a default
  there is a new override per file that writes into the props, against one line at the read.

## Tests

- `TestDatabricksClusterWorkers` in `tests/spark_rapids_tools_ut/test_cluster.py`, parametrized
  over the AWS and Azure platforms, loads the existing `{aws,azure}-cpu-00.json` fixtures with
  the `executors` entry removed and builds the cluster through `load_cluster_by_prop` (no CLI
  call on that path).
- `test_zero_worker_cluster_raises_no_workers_error`: `num_workers: 0` raises the
  `RuntimeError` from `_verify_workers_exist`; on `dev` both platforms fail it with the
  `TypeError`.
- `test_terminated_cluster_generates_workers`: `num_workers: 2` yields two generated workers,
  with and without the change.
- The whole `spark_rapids_tools_ut` set passes (313). pylint 10.00/10 and flake8 clean.
