### PR TITLE
Read the current Databricks event log last in every time zone

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/EventLogPathProcessor.scala
@@ -461,8 +461,9 @@ object EventLogPathProcessor extends Logging {
     }
     val fileParts = eventLogFileName.split("--")
     if (fileParts.size < 2) {
-      // assume this is the current log and we want that one to be read last
-      LocalDateTime.now()
+      // the undated current log is always the newest; a local-zone now() compared against the
+      // UTC stamps of the rolled files sorted it first for hours after a rotation west of UTC
+      LocalDateTime.MAX
     } else {
       val date = fileParts(0).split("-")
       val day = Integer.parseInt(date(3))

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationNoSparkSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/qualification/QualificationNoSparkSuite.scala
@@ -16,13 +16,17 @@
 
 package com.nvidia.spark.rapids.tool.qualification
 
+import java.nio.file.{Files, Paths}
+import java.time.LocalDateTime
+
 import com.nvidia.spark.rapids.BaseNoSparkSuite
-import com.nvidia.spark.rapids.tool.{PlatformNames, StatusReportCounts, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.{EventLogPathProcessor, PlatformNames, StatusReportCounts, ToolTestUtils}
 import com.nvidia.spark.rapids.tool.qualification.checkers.{QToolOutFileCheckerImpl, QToolOutJsonFileCheckerImpl, QToolResultCoreChecker, QToolStatusChecker, QToolTestCtxtBuilder}
 import org.json4s.DefaultFormats
 import org.json4s.jackson.JsonMethods
 import org.scalatest.matchers.should.Matchers._
 
+import org.apache.spark.sql.TrampolineUtil
 import org.apache.spark.sql.rapids.tool.{SourceClusterInfo, ToolUtils}
 import org.apache.spark.sql.rapids.tool.util.UTF8Source
 
@@ -353,6 +357,47 @@ class QualificationNoSparkSuite extends BaseNoSparkSuite {
           .withTableLabel("perSqlCSVReport")
           .withExpectedLoc(expectedQualLoc(expectedLabel)))
       .build()
+  }
+
+  test("db event log rolling with a rolled file dated after the current file") {
+    // The rolled file names carry the rotation time; the current file has no stamp and is dated
+    // when the directory is read. A rolled stamp later than that moment (a rotation shortly
+    // before the run, read from a machine whose local clock is behind the stamp's zone) must
+    // still sort before the current file, or the events replay out of order and every SQL
+    // spanning the rotation loses its duration. The copy renames the rolled file to a
+    // far-future stamp and expects the same output as the original fixture.
+    val srcDir = Paths.get(qualEventLog("db_sim_eventlog"))
+    val expectedLabel = "db_eventlog_rolling"
+    TrampolineUtil.withTempDir { tempDir =>
+      Files.copy(srcDir.resolve("eventlog"), Paths.get(tempDir.getAbsolutePath, "eventlog"))
+      Files.copy(srcDir.resolve("eventlog-2021-06-15--15-00.gz"),
+        Paths.get(tempDir.getAbsolutePath, "eventlog-2099-12-31--23-59.gz"))
+      QToolTestCtxtBuilder(eventlogs = Array(tempDir.getAbsolutePath))
+        .withPerSQL()
+        .withChecker(
+          QToolStatusChecker("Check that the app should succeed")
+            .withExpectedCounts(StatusReportCounts(1, 0, 0, 0)))
+        .withChecker(
+          QToolResultCoreChecker("check app count is valid and status is success")
+            .withExpectedSize(1)
+            .withSuccessCode())
+        .withChecker(
+          QToolOutFileCheckerImpl("check the core app summaries has valid data")
+            .withExpectedRows("expect only 1 row", 1)
+            .withExpectedLoc(expectedQualLoc(expectedLabel)))
+        .withChecker(
+          QToolOutFileCheckerImpl("Per-SQL table content")
+            .withTableLabel("perSqlCSVReport")
+            .withExpectedLoc(expectedQualLoc(expectedLabel)))
+        .build()
+    }
+  }
+
+  test("the undated current db event log is dated after every rolled file") {
+    val current = EventLogPathProcessor.getDBEventLogFileDate("eventlog")
+    val rolled = EventLogPathProcessor.getDBEventLogFileDate("eventlog-2099-12-31--23-59.gz")
+    assert(current == LocalDateTime.MAX)
+    assert(rolled.isBefore(current))
   }
 
   runConditionalTest("nds q86 with failure test",


### PR DESCRIPTION
Fixes #2141

## Problem

A Databricks log-delivery directory holds the current `eventlog` and rolled
`eventlog-YYYY-MM-DD--HH-MM.gz` files. `EventLogPathProcessor.getDBEventLogFileDate` dated the
current file `LocalDateTime.now()` in the machine's zone and the rolled files by their stamps,
which are UTC wall time: in the Databricks 17.3 log this came from, the file named `18-20`
ends at 18:19:55Z and the current file starts at 18:20:00Z. On a machine west of UTC, for up
to the zone offset after a rotation, the current file sorted first and the events were
processed out of order:

- every SQL, job and stage spanning the rotation lost its duration;
- `totalCoreSeconds` was 0 and `removed_executors.csv` was missing, because the executor's
  removal was processed before its addition;
- nothing was logged: `doSparkListenerSQLExecutionEnd` drops an end event whose start it has
  not seen.

Both the profiling and the qualification tool read directories through this path.

## Fix

The undated current file is by definition the newest, so it is now dated `LocalDateTime.MAX`.

- `LocalDateTime.now(ZoneOffset.UTC)` would fix the zone but still depend on the reader's
  clock and still race with a rotation in the same minute; a sentinel needs no clock.
- The value is only ever compared in the file sort, never logged or added to, so nothing else
  changes.
- Two undated files would tie and keep their listing order; a Databricks directory has one.
- `modificationTime` and `fileSizeForLastIndex` (unused today) read the last file of the sorted
  list, which is now always the current file.

## Tests

- `QualificationNoSparkSuite`, "db event log rolling with a rolled file dated after the current
  file": the `db_sim_eventlog` fixture copied into a temp directory with the rolled file renamed
  to `eventlog-2099-12-31--23-59.gz`, checked against the same expected files as the existing
  "db event log rolling" test, since the log content is unchanged. It reproduces the misorder
  in any zone at any time of day: on `dev` SQL 0 has an empty duration and App Duration is 0,
  and the test fails; with the change SQL 0 = 119903 ms and App Duration = 133857 ms.
- `QualificationNoSparkSuite`, "the undated current db event log is dated after every rolled
  file": asserts `getDBEventLogFileDate("eventlog")` directly.
- `QualificationNoSparkSuite`: 48 tests pass with the change, the two new ones fail without it.
  `ApplicationInfoSuite` passes. Scalastyle clean.
