### PR TITLE
Add Databricks 14.3 and 17.3 to the AutoTuner shuffle manager map

### DIFF
--- a/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
+++ b/core/src/main/scala/com/nvidia/spark/rapids/tool/Platform.scala
@@ -844,7 +844,9 @@ abstract class DatabricksPlatform(gpuDevice: Option[GpuDevice],
   // TODO: Issue to automate this https://github.com/NVIDIA/cudf-spark-tools/issues/1676
   override val supportedShuffleManagerVersionMap: Array[(String, String)] = Array(
     "12.2" -> "332db",
-    "13.3" -> "341db"
+    "13.3" -> "341db",
+    "14.3" -> "350db143",
+    "17.3" -> "400db173"
   )
 
   override def createClusterInfo(coresPerExecutor: Int,

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -57,6 +57,38 @@ abstract class ProfilingAutoTunerSuiteBase extends BaseAutoTunerSuite {
   }
 
   /**
+   * Helper method to verify that the recommended shuffle manager version matches the
+   * expected version.
+   */
+  protected def verifyRecommendedShuffleManagerVersion(
+                                                      autoTuner: AutoTuner,
+                                                      expectedSmVersion: String): Unit = {
+    autoTuner.getShuffleManagerClassName match {
+      case Right(smClassName) =>
+        assert(smClassName == ProfilingAutoTunerHelper
+          .buildShuffleManagerClassName(expectedSmVersion))
+      case Left(comment) =>
+        fail(s"Expected valid RapidsShuffleManager but got comment: $comment")
+    }
+  }
+
+  /**
+   * Helper method to verify that the shuffle manager version is not recommended
+   * for the unsupported Spark version.
+   */
+  protected def verifyUnsupportedSparkVersionForShuffleManager(
+                                                              autoTuner: AutoTuner,
+                                                              sparkVersion: String): Unit = {
+    autoTuner.getShuffleManagerClassName match {
+      case Right(smClassName) =>
+        fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
+      case Left(comment) =>
+        assert(comment == shuffleManagerCommentForUnsupportedVersion(sparkVersion,
+          autoTuner.platform))
+    }
+  }
+
+  /**
    * Helper method to extract the AutoTuner results from the profile log content
    * TODO: We should store the AutoTuner results in a separate file.
    */
@@ -2310,22 +2342,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
     compareOutput(expectedResults, autoTunerOutput)
   }
 
-  /**
-   * Helper method to verify that the recommended shuffle manager version matches the
-   * expected version.
-   */
-  private def verifyRecommendedShuffleManagerVersion(
-                                                      autoTuner: AutoTuner,
-                                                      expectedSmVersion: String): Unit = {
-    autoTuner.getShuffleManagerClassName match {
-      case Right(smClassName) =>
-        assert(smClassName == ProfilingAutoTunerHelper
-          .buildShuffleManagerClassName(expectedSmVersion))
-      case Left(comment) =>
-        fail(s"Expected valid RapidsShuffleManager but got comment: $comment")
-    }
-  }
-
   val dbPlatform: Platform = PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS)
   dbPlatform.supportedShuffleManagerVersionMap.foreach { case (dbVersion, smVersion) =>
     test(s"test shuffle manager version for supported databricks version - $dbVersion") {
@@ -2367,22 +2383,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
     verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "330")
   }
 
-  /**
-   * Helper method to verify that the shuffle manager version is not recommended
-   * for the unsupported Spark version.
-   */
-  private def verifyUnsupportedSparkVersionForShuffleManager(
-                                                              autoTuner: AutoTuner,
-                                                              sparkVersion: String): Unit = {
-    autoTuner.getShuffleManagerClassName match {
-      case Right(smClassName) =>
-        fail(s"Expected error comment but got valid RapidsShuffleManager: $smClassName")
-      case Left(comment) =>
-        assert(comment == shuffleManagerCommentForUnsupportedVersion(sparkVersion,
-          autoTuner.platform))
-    }
-  }
-
   test("test shuffle manager version for unsupported databricks version") {
     val databricksVersion = "9.1.x-gpu-ml-scala2.12"
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
@@ -2395,36 +2395,6 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
       infoProvider,
       PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
-  }
-
-  test("test shuffle manager version for supported databricks version - 17.3 on scala 2.13") {
-    val databricksVersion = "17.3.x-gpu-ml-scala2.13"
-    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
-      mutable.Map("spark.rapids.sql.enabled" -> "true",
-        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
-        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
-      Some(databricksVersion), Seq())
-    val autoTuner = buildAutoTunerForTests(
-      infoProvider,
-      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AZURE))
-    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "400db173")
-  }
-
-  test("test shuffle manager version for databricks version without a plugin shim - 15.4") {
-    val databricksVersion = "15.4.x-gpu-ml-scala2.12"
-    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
-      mutable.Map("spark.rapids.sql.enabled" -> "true",
-        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
-        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
-      Some(databricksVersion), Seq())
-    val autoTuner = buildAutoTunerForTests(
-      infoProvider,
-      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
-    verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
-    // the comment points the user at the newest supported runtime, which must be 17.3
-    val (latestVersion, latestSmVersion) = autoTuner.platform.latestSupportedShuffleManagerInfo
-    assert(latestVersion == "17.3")
-    assert(latestSmVersion == "400db173")
   }
 
   test("test shuffle manager version for unsupported spark version") {

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuite.scala
@@ -2397,6 +2397,36 @@ class ProfilingAutoTunerSuite extends ProfilingAutoTunerSuiteBase {
     verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
   }
 
+  test("test shuffle manager version for supported databricks version - 17.3 on scala 2.13") {
+    val databricksVersion = "17.3.x-gpu-ml-scala2.13"
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      mutable.Map("spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
+        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
+      Some(databricksVersion), Seq())
+    val autoTuner = buildAutoTunerForTests(
+      infoProvider,
+      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AZURE))
+    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "400db173")
+  }
+
+  test("test shuffle manager version for databricks version without a plugin shim - 15.4") {
+    val databricksVersion = "15.4.x-gpu-ml-scala2.12"
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      mutable.Map("spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
+        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
+      Some(databricksVersion), Seq())
+    val autoTuner = buildAutoTunerForTests(
+      infoProvider,
+      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
+    verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
+    // the comment points the user at the newest supported runtime, which must be 17.3
+    val (latestVersion, latestSmVersion) = autoTuner.platform.latestSupportedShuffleManagerInfo
+    assert(latestVersion == "17.3")
+    assert(latestSmVersion == "400db173")
+  }
+
   test("test shuffle manager version for unsupported spark version") {
     val sparkVersion = "3.1.2"
     val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/tuning/ProfilingAutoTunerSuiteV2.scala
@@ -19,6 +19,7 @@ package com.nvidia.spark.rapids.tool.tuning
 import scala.collection.mutable
 
 import com.nvidia.spark.rapids.tool.{DynamicAllocationInfo, GpuTypes, NodeInstanceMapKey, PlatformFactory, PlatformInstanceTypes, PlatformNames, ToolTestUtils}
+import com.nvidia.spark.rapids.tool.planparser.db.DBVersionExtractor
 import com.nvidia.spark.rapids.tool.profiling.{Profiler, PySparkMemoryEvidence,
   RecommendedCommentResult, ShuffleStageInputAnalysis}
 import com.nvidia.spark.rapids.tool.tuning.config.{ConfTypeEnum, TuningConfigEntry,
@@ -3761,6 +3762,52 @@ class ProfilingAutoTunerSuiteV2 extends ProfilingAutoTunerSuiteBase {
     assert(values("spark.executor.pyspark.memory") == "4g")
     assert(values("spark.kubernetes.resource.type") == "python")
     assert(!values.contains("spark.yarn.isPython"))
+  }
+
+  // The Databricks entries of supportedShuffleManagerVersionMap. The map-driven tests in
+  // ProfilingAutoTunerSuite take both the runtime and the expected class from the map, so a
+  // wrong or missing entry stays green there; these pin the expected values independently.
+  test("test shuffle manager version for databricks 14.3 is 350db143") {
+    val databricksVersion = "14.3.x-gpu-ml-scala2.12"
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      mutable.Map("spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
+        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
+      Some(databricksVersion), Seq())
+    val autoTuner = buildAutoTunerForTests(
+      infoProvider,
+      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
+    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "350db143")
+  }
+
+  test("test shuffle manager version for databricks 17.3 on scala 2.13 is 400db173") {
+    val databricksVersion = "17.3.x-gpu-ml-scala2.13"
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      mutable.Map("spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
+        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
+      Some(databricksVersion), Seq())
+    val autoTuner = buildAutoTunerForTests(
+      infoProvider,
+      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AZURE))
+    verifyRecommendedShuffleManagerVersion(autoTuner, expectedSmVersion = "400db173")
+  }
+
+  test("test shuffle manager version for databricks 15.4 without a plugin shim") {
+    val databricksVersion = "15.4.x-gpu-ml-scala2.12"
+    val infoProvider = getMockInfoProvider(0, Seq(0), Seq(0.0),
+      mutable.Map("spark.rapids.sql.enabled" -> "true",
+        "spark.plugins" -> "com.nvidia.spark.AnotherPlugin, com.nvidia.spark.SQLPlugin",
+        DBVersionExtractor.DB_SPARK_VERSION_KEY -> databricksVersion),
+      Some(databricksVersion), Seq())
+    val autoTuner = buildAutoTunerForTests(
+      infoProvider,
+      PlatformFactory.createInstance(PlatformNames.DATABRICKS_AWS))
+    verifyUnsupportedSparkVersionForShuffleManager(autoTuner, databricksVersion)
+    // the comment points the user at the newest supported runtime, which must be 17.3
+    val (latestVersion, latestSmVersion) = autoTuner.platform.latestSupportedShuffleManagerInfo
+    assert(latestVersion == "17.3")
+    assert(latestSmVersion == "400db173")
   }
 
 }


### PR DESCRIPTION
Fixes #2144 , Fixes #1678.

## Problem

On a Databricks 14.3 or 17.3 event log the profiling AutoTuner commented "Cannot recommend
RAPIDS Shuffle Manager for unsupported Databricks runtime" and advised moving to runtime 13.3,
whose shim the plugin has dropped (NVIDIA/cudf-spark#15276). The Databricks entries of
`DatabricksPlatform.supportedShuffleManagerVersionMap` stopped at 13.3 while the plugin ships
`com.nvidia.spark.rapids.spark350db143.RapidsShuffleManager` and
`com.nvidia.spark.rapids.spark400db173.RapidsShuffleManager`, the two classes the shuffle
documentation page linked from the comment lists for Databricks. Databricks sets
`spark.shuffle.manager=SORT` explicitly, so the plugin's automatic configuration does not apply
and the tuner's recommendation is the only place in the tools' output where a user is told the
class name.

## Fix

The map gains `14.3 -> 350db143` and `17.3 -> 400db173`.

- The 12.2 and 13.3 entries stay, so event logs from older runtimes keep their recommendation
  (#1678).
- The "e.g." runtime in the unsupported-version comment becomes 17.3 through the existing
  `maxBy`, which compares version strings and orders `12.2 < 13.3 < 14.3 < 17.3` correctly.
- `getShuffleManagerVersion` matches by `contains`; no key is a substring of another key.
- Both Databricks shims are enabled by default in the plugin, the open question on #1678: the
  14.3 shim since NVIDIA/cudf-spark#12485, the 17.3 shim from its first release
  (NVIDIA/cudf-spark#14360); both providers read `getOrElse(true)`. Databricks 14.3 is Spark
  3.5.0 and 17.3 is Spark 4.0.0.
  `buildShuffleManagerClassName` needs no change for the `NNNdb` scheme. #1676 (generate the
  list from the plugin) would subsume this.
- Scope: the profiling AutoTuner on Databricks AWS and Azure, which share `DatabricksPlatform`.
  Qualification never recommends a shuffle manager (#1813). Event logs from 12.2 and 13.3 get
  the same recommendation as before.

## Tests

- The per-entry Databricks test in `ProfilingAutoTunerSuite`
  (`dbPlatform.supportedShuffleManagerVersionMap.foreach`) runs the two entries, but it takes
  both the runtime and the expected class from the map, so it pins nothing on its own.
- Three cases in `ProfilingAutoTunerSuiteV2` (the deprecated suite's header sends new AutoTuner
  cases there) pin the values with the expected class written out: "test shuffle manager
  version for databricks 14.3 is 350db143", "test shuffle manager version for databricks 17.3 on
  scala 2.13 is 400db173" (the `-scala2.13` runtime suffix, on the Azure platform), and "test
  shuffle manager version for databricks 15.4 without a plugin shim", which expects the
  unsupported-version comment and asserts `latestSupportedShuffleManagerInfo` is the 17.3 pair.
  All three fail on `dev` without the two entries.
- `verifyRecommendedShuffleManagerVersion` and `verifyUnsupportedSparkVersionForShuffleManager`
  move from the deprecated suite into `ProfilingAutoTunerSuiteBase`, unchanged, so both suites
  share them.
- `ProfilingAutoTunerSuite` and `ProfilingAutoTunerSuiteV2` together: 198 succeeded, 0 failed
  with the change (JDK 17, Scala 2.12); scalastyle clean.
- Profiling a Databricks 17.3 GPU event log with the change recommends
  `spark.shuffle.manager=com.nvidia.spark.rapids.spark400db173.RapidsShuffleManager` and no
  longer prints the "Cannot recommend RAPIDS Shuffle Manager for unsupported Databricks
  runtime" comment.
