### PR TITLE
Map the Photon nodes Databricks 15.4 and 17.3 added to their Spark equivalents

### DIFF
--- a/core/src/main/resources/parser/photon/databricks-13_3.json
+++ b/core/src/main/resources/parser/photon/databricks-13_3.json
@@ -4,7 +4,8 @@
     "Some entries have one-to-many mappings. For example, 'PhotonAgg' can map to either 'HashAggregate', 'SortAggregate', or 'ObjectHashAggregate'.",
     "Currently, only the first mapping in the list is used.",
     "This limitation exists because we cannot differentiate between these operators in the SparkPlan.",
-    "TODO: Create separate mapping file for different Photon/Databricks versions"
+    "TODO: Create separate mapping file for different Photon/Databricks versions",
+    "The entries after PhotonWindow appear in Databricks 15.4 and 17.3 Photon plans and not in 13.3 plans; the mapping is additive, so they are harmless on older runtimes."
   ],
   "PhotonAdapter": [
     "Scan"
@@ -102,5 +103,26 @@
   "PhotonWindow": [
     "Window",
     "RunningWindowFunction"
+  ],
+  "PhotonWriteStage": [
+    "WholeStageCodegen"
+  ],
+  "PhotonParquetWriter": [
+    "WriteFiles"
+  ],
+  "PhotonColumnarToRow": [
+    "ColumnarToRow"
+  ],
+  "PhotonMetadataSubquery": [
+    "Subquery"
+  ],
+  "PhotonRuntimeFilterSource": [
+    "Subquery"
+  ],
+  "PhotonRange": [
+    "Range"
+  ],
+  "PhotonJsonScan": [
+    "Scan"
   ]
 }

--- a/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/PhotonPlanParserSuite.scala
+++ b/core/src/test/scala/com/nvidia/spark/rapids/tool/planparser/PhotonPlanParserSuite.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2026, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package com.nvidia.spark.rapids.tool.planparser
 
 import com.nvidia.spark.rapids.tool.PlatformNames
+import com.nvidia.spark.rapids.tool.planparser.db.PhotonOssOpMapper
 import com.nvidia.spark.rapids.tool.qualification.PluginTypeChecker
 
 
@@ -67,5 +68,30 @@ class PhotonPlanParserSuite extends BasePlanParserSuite {
       assert(!photonOpExists,
         s"Failed to parse Photon operator $photonName as Spark operator $sparkName")
     }
+  }
+
+  // Photon nodes that appear in Databricks 15.4 and 17.3 plans and not in the 13.3 log above.
+  // Each expected value is written out, so a wrong or missing entry in the mapping file fails
+  // here rather than passing through the generic parser as an unsupported exec.
+  val photonOpTestCasesNewerRuntimes: Seq[(String, String)] = Seq(
+    "PhotonWriteStage" -> "WholeStageCodegen",
+    "PhotonParquetWriter" -> "WriteFiles",
+    "PhotonColumnarToRow" -> "ColumnarToRow",
+    "PhotonMetadataSubquery" -> "Subquery",
+    "PhotonRuntimeFilterSource" -> "Subquery",
+    "PhotonRange" -> "Range",
+    "PhotonJsonScan" -> "Scan"
+  )
+
+  test("Photon operators from Databricks 15.4 and 17.3 map to their Spark equivalents") {
+    photonOpTestCasesNewerRuntimes.foreach { case (photonName, sparkName) =>
+      assert(PhotonOssOpMapper.mapContentToOss(photonName) == sparkName,
+        s"$photonName should map to $sparkName")
+    }
+    // The scan keeps its format suffix, as PhotonScan does, so the read parser sees "Scan json".
+    assert(PhotonOssOpMapper.mapContentToOss("PhotonJsonScan json") == "Scan json")
+    // A Photon node with no entry is left as it is; that is what the generic parser then reports
+    // as unsupported.
+    assert(PhotonOssOpMapper.mapContentToOss("PhotonNotARealNode") == "PhotonNotARealNode")
   }
 }


### PR DESCRIPTION
Fixes #2158

## Problem

On a Databricks 15.4 or 17.3 Photon event log, `spark_rapids qualification` lists Photon nodes
that did not exist on 13.3 as unsupported execs, `Exec, Unsupported, Triage` in
`unsupported_operators.csv`. The Photon-to-Spark mapping is one file,
`parser/photon/databricks-13_3.json`, loaded by `PhotonOssOpMapper` for every runtime. A Photon
name with no entry is left as it is and the generic parser reports it as unsupported. On a 17.3
Delta MERGE log, seven of the 21 Photon node names have no entry (`PhotonWriteStage`,
`PhotonParquetWriter`, `PhotonMetadataSubquery`, `PhotonRuntimeFilterSource`,
`PhotonColumnarToRow`, `PhotonRange`, `PhotonJsonScan`) and they land in 39 of 121 SQLs:

```
10,35,21,Exec,"PhotonWriteStage","Unsupported",2603,312028,Triage
10,35,22,Exec,"PhotonParquetWriter","Unsupported",2603,312028,Triage
10,22,24,Exec,"PhotonMetadataSubquery","Unsupported",1324,312028,Triage
10,22,28,Exec,"PhotonRuntimeFilterSource","Unsupported",1324,312028,Triage
```

The write pair sits under `Execute WriteIntoDeltaCommand`, which the tools already recognise,
so the command is scored while its own writer counts against it. The file's header carries a
TODO for per-version files and #1384 asks for the same.

## Fix

Seven entries in `databricks-13_3.json`, each the Spark node the tools already score or set
aside, the way the existing entries map Photon's stage wrappers and scans.

- `PhotonWriteStage -> WholeStageCodegen`, as `PhotonShuffleMapStage`, `PhotonResultStage` and
  `PhotonUnionShuffleMapStage` already do. `PhotonParquetWriter -> WriteFiles`, the physical
  writer under the write command (`WriteFilesExec` in `supportedExecs.csv`, and one of the
  supported blank execs).
- `PhotonMetadataSubquery -> Subquery` and `PhotonRuntimeFilterSource -> Subquery`. Both are
  pointer nodes: in the log each has zero exec duration and no children and sits inside the
  scan's own stage, whose time is scored through the scan and filter. That is the shape
  `SubqueryExecParser` describes ("a collect execution pointing to an actual one", driver-side
  metrics) and removes from the estimate, and it is where the OSS forms of the same two things
  land, a runtime filter being a bloom-filter aggregate subquery and metadata pruning a
  dynamic-pruning subquery. EMR's `GenerateBloomFilter` gets the same treatment on
  `execsToBeRemoved`. `SubqueryBroadcast` would instead count a Photon-only filter build as
  supported work, so it was not used. With the mapping these rows reappear as `Subquery` under
  IgnoreNoPerf and the stage time stays with the scans. This is the one judgment call in the
  set.
- `PhotonColumnarToRow -> ColumnarToRow` (also on `execsToBeRemoved`), `PhotonRange -> Range`
  (`RangeExec`), `PhotonJsonScan -> Scan`, which keeps the format suffix the way `PhotonScan`
  does and gives the read parser `Scan json`.
- Additive and version-agnostic: a 13.3 plan never contains these names, so the 13.3 fixture
  and its expectation files are unchanged. None of the seven means something different on
  another runtime, so this does not pre-empt #1384, which stays for a mapping that diverges.
  The file keeps its name, since renaming it touches `PhotonOssOpMapper` and the design in
  #1384.
- Databricks AWS and Azure, qualification and profiling, since both go through
  `PhotonOssOpMapper.toPlatformAwarePlan`.

## Tests

- `PhotonPlanParserSuite`, "Photon operators from Databricks 15.4 and 17.3 map to their Spark
  equivalents": one assertion per entry with the expected name written out, through
  `PhotonOssOpMapper.mapContentToOss`, plus `PhotonJsonScan json -> Scan json` and an unmapped
  name left unchanged. Fails on `dev` at its first pin, `"[PhotonWriteStage]" did not equal
  "[WholeStageCodegen]"`. The existing 13.3 log test in the suite is unchanged and still
  passes. No log fixture is added: the 17.3 log is far
  above the suite's largest fixture, and the mapping is a name substitution the string test
  exercises directly.
- `PhotonPlanParserSuite`: 2 succeeded, 0 failed with the change. Scalastyle clean.
- Qualifying the 17.3 Photon log with the change, same tool build, same log: the seven names
  leave `unsupported_operators.csv` (71 rows over 39 SQLs to 0), the unsupported stage share
  moves from 49.26% to 28.45%, the estimated speedup from 1.05x to 1.15x, and `execs.csv` shows
  `WriteFiles`, `Subquery`, `Range` and `Scan json` where the Photon names were. The 71 Triage
  rows become 32 rows under ignore actions, 28 `Subquery` and 3 `ColumnarToRow` as
  IgnoreNoPerf and the JSON scan as a `ReadDeltaLog` IgnorePerf (it is the Delta log read),
  none of which counts toward the estimate. The other 721 rows are unchanged. The app stays
  Not Recommended on the share that remains, which is the Delta commands and the rest of the
  plan, not these nodes.
